### PR TITLE
Fix 2.0.0.1 sourceUrl

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
         "version": "2.0.0.1",
         "changelog": "Compatibility update for JF 10.8.x.; rebased with latest changes from master.",
         "targetAbi": "10.8.0.0",
-        "sourceUrl": "https://github.com/lyarenei/jellyfin-plugin-listenbrainz/releases/download/2.0.0.0-alpha/listenbrainz_2.0.0.0-alpha.zip",
+        "sourceUrl": "https://github.com/lyarenei/jellyfin-plugin-listenbrainz/releases/download/2.0.0.1-alpha/listenbrainz_2.0.0.1-alpha.zip",
         "checksum": "dac23e04aa07bc5f1aea879cd1623dee",
         "timestamp": "2022-03-25"
       },


### PR DESCRIPTION
It was still pointing at the 2.0.0.0-alpha zip (but with updated checksum, so it won't install)