### PR TITLE
Send full artist credit in listens

### DIFF
--- a/Jellyfin.Plugin.Listenbrainz.Tests/RecordingTest.cs
+++ b/Jellyfin.Plugin.Listenbrainz.Tests/RecordingTest.cs
@@ -1,0 +1,33 @@
+using System.Collections.ObjectModel;
+using Jellyfin.Plugin.Listenbrainz.Models.Musicbrainz;
+using Xunit;
+
+namespace Jellyfin.Plugin.Listenbrainz.Tests;
+
+public class RecordingTest
+{
+    protected ArtistCredit _artistCredit1 = new()
+    {
+        JoinPhrase = " with ",
+        Name = "Artist 1"
+    };
+
+    private ArtistCredit _artistCredit2 = new()
+    {
+        Name = "Artist 2"
+    };
+
+    public Recording _example = new()
+    {
+        Id = "recordingId",
+        Score = 99
+    };
+
+    [Fact]
+    public void Recording_GetCreditString()
+    {
+        var creditList = new[] { _artistCredit1, _artistCredit2 };
+        _example.ArtistCredit = new Collection<ArtistCredit>(creditList);
+        Assert.Equal("Artist 1 with Artist 2", _example.GetCreditString());
+    }
+}

--- a/Jellyfin.Plugin.Listenbrainz/Clients/ListenbrainzClient.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Clients/ListenbrainzClient.cs
@@ -110,10 +110,7 @@ public class ListenbrainzClient : BaseListenbrainzClient
     /// <param name="jfUser">Jellyfin user. Used for logging.</param>
     public async void NowPlaying(Audio item, LbUser user, User jfUser)
     {
-        var listenRequest = new SubmitListenRequest("playing_now", item)
-        {
-            ApiToken = user.Token
-        };
+        var listenRequest = new SubmitListenRequest("playing_now", item) { ApiToken = user.Token };
 
         // Fetch Recording data
         Debug.Assert(_mbClient != null, nameof(_mbClient) + " != null");

--- a/Jellyfin.Plugin.Listenbrainz/Clients/ListenbrainzClient.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Clients/ListenbrainzClient.cs
@@ -73,6 +73,9 @@ public class ListenbrainzClient : BaseListenbrainzClient
             {
                 // Set recording MBID as Jellyfin does not store it
                 request.SetRecordingMbId(recordingData.Id);
+
+                // Set correct artist credit per MusicBrainz entry.
+                request.SetArtist(recordingData.GetCreditString());
             }
         }
         else
@@ -122,6 +125,9 @@ public class ListenbrainzClient : BaseListenbrainzClient
             {
                 // Set recording MBID as Jellyfin does not store it
                 listenRequest.SetRecordingMbId(recordingData.Id);
+
+                // Set correct artist credit per MusicBrainz entry.
+                listenRequest.SetArtist(recordingData.GetCreditString());
             }
         }
         else

--- a/Jellyfin.Plugin.Listenbrainz/Clients/ListenbrainzClient.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Clients/ListenbrainzClient.cs
@@ -63,20 +63,21 @@ public class ListenbrainzClient : BaseListenbrainzClient
     {
         request.ApiToken = user.Token;
 
-        // Workaround for Jellyfin not storing recording MBID
-        if (!request.HasRecordingMbId())
+        // Fetch Recording data
+        Debug.Assert(_mbClient != null, nameof(_mbClient) + " != null");
+        var trackMbId = request.GetTrackMbId();
+        if (trackMbId != null)
         {
-            Debug.Assert(_mbClient != null, nameof(_mbClient) + " != null");
-            var trackMbId = request.GetTrackMbId();
-            if (trackMbId != null)
+            var recordingData = await _mbClient.GetRecordingData(trackMbId).ConfigureAwait(true);
+            if (recordingData != null)
             {
-                var recordingMbId = await _mbClient.GetRecordingId(trackMbId).ConfigureAwait(false);
-                request.SetRecordingMbId(recordingMbId);
+                // Set recording MBID as Jellyfin does not store it
+                request.SetRecordingMbId(recordingData.Id);
             }
-            else
-            {
-                _logger.LogDebug("No track MBID available, cannot get recording MBID");
-            }
+        }
+        else
+        {
+            _logger.LogDebug("No track MBID available, cannot get additional recording data");
         }
 
         try
@@ -114,20 +115,21 @@ public class ListenbrainzClient : BaseListenbrainzClient
             ApiToken = user.Token
         };
 
-        // Workaround for Jellyfin not storing recording MBID
-        if (!listenRequest.HasRecordingMbId())
+        // Fetch Recording data
+        Debug.Assert(_mbClient != null, nameof(_mbClient) + " != null");
+        var trackMbId = listenRequest.GetTrackMbId();
+        if (trackMbId != null)
         {
-            Debug.Assert(_mbClient != null, nameof(_mbClient) + " != null");
-            var trackMbId = listenRequest.GetTrackMbId();
-            if (trackMbId != null)
+            var recordingData = await _mbClient.GetRecordingData(trackMbId).ConfigureAwait(true);
+            if (recordingData != null)
             {
-                var recordingMbId = await _mbClient.GetRecordingId(trackMbId).ConfigureAwait(false);
-                listenRequest.SetRecordingMbId(recordingMbId);
+                // Set recording MBID as Jellyfin does not store it
+                listenRequest.SetRecordingMbId(recordingData.Id);
             }
-            else
-            {
-                _logger.LogDebug("No track MBID available, cannot get recording MBID");
-            }
+        }
+        else
+        {
+            _logger.LogDebug("No track MBID available, cannot get additional recording data");
         }
 
         try

--- a/Jellyfin.Plugin.Listenbrainz/Clients/MusicbrainzClient.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Clients/MusicbrainzClient.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Listenbrainz.Models.Musicbrainz;
 using Jellyfin.Plugin.Listenbrainz.Models.Musicbrainz.Requests;
 using Jellyfin.Plugin.Listenbrainz.Models.Musicbrainz.Responses;
 using Jellyfin.Plugin.Listenbrainz.Services;
@@ -30,27 +31,27 @@ public class MusicbrainzClient : BaseMusicbrainzClient
     }
 
     /// <summary>
-    /// Get recording MBID by track MBID.
+    /// Get recording data by track MBID.
     /// </summary>
     /// <param name="trackId">ID of the track.</param>
-    /// <returns>Recording MBID. Null if error or not found.</returns>
-    public async Task<string?> GetRecordingId(string trackId)
+    /// <returns>An instance of <see cref="Recording"/>. Null if error or not found.</returns>
+    public async Task<Recording?> GetRecordingData(string trackId)
     {
-        _logger.LogDebug("Getting Recording MBID for Track: {TrackMbId}", trackId);
-        var response = await Get<RecordingIdRequest, RecordingsResponse>(new RecordingIdRequest(trackId)).ConfigureAwait(false);
+        _logger.LogDebug("Getting Recording data for Track: {TrackMbId}", trackId);
+        var response = await Get<RecordingIdRequest, RecordingsResponse>(new RecordingIdRequest(trackId)).ConfigureAwait(true);
         if (response == null || response.IsError())
         {
-            _logger.LogInformation("Failed to retrieve Recording ID for '{TrackMbId}'", trackId);
+            _logger.LogInformation("Failed to retrieve Recording data for '{TrackMbId}'", trackId);
             return null;
         }
 
         var recording = response.Recordings.MaxBy(r => r.Score);
         if (recording != null)
         {
-            return recording.Id;
+            return recording;
         }
 
-        _logger.LogInformation("Recording ID for track '{TrackMbId}' not found", trackId);
+        _logger.LogInformation("Recording data for track '{TrackMbId}' not found", trackId);
         return null;
     }
 }

--- a/Jellyfin.Plugin.Listenbrainz/Jellyfin.Plugin.Listenbrainz.csproj
+++ b/Jellyfin.Plugin.Listenbrainz/Jellyfin.Plugin.Listenbrainz.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Listenbrainz</RootNamespace>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <AssemblyVersion>2.1.0.1</AssemblyVersion>
+    <FileVersion>2.1.0.1</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Jellyfin.Plugin.Listenbrainz/Jellyfin.Plugin.Listenbrainz.csproj
+++ b/Jellyfin.Plugin.Listenbrainz/Jellyfin.Plugin.Listenbrainz.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Listenbrainz</RootNamespace>
-    <AssemblyVersion>2.0.0.8</AssemblyVersion>
-    <FileVersion>2.0.0.8</FileVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Jellyfin.Plugin.Listenbrainz/Models/Listenbrainz/Requests/SubmitListenRequest.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Models/Listenbrainz/Requests/SubmitListenRequest.cs
@@ -74,4 +74,13 @@ public class SubmitListenRequest : BaseRequest
     {
         return Data[0].Data.Info?.TrackMbId;
     }
+
+    /// <summary>
+    /// Set artist name.
+    /// </summary>
+    /// <param name="artistName">Artist name.</param>
+    public void SetArtist(string artistName)
+    {
+        Data[0].Data.ArtistName = artistName;
+    }
 }

--- a/Jellyfin.Plugin.Listenbrainz/Models/Musicbrainz/Recording.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Models/Musicbrainz/Recording.cs
@@ -68,7 +68,7 @@ public class ArtistCredit
     /// <summary>
     /// Gets or sets join phrase.
     /// </summary>
-    [JsonPropertyName("Joinphrase")]
+    [JsonPropertyName("joinphrase")]
     public string JoinPhrase { get; set; }
 
     /// <summary>

--- a/Jellyfin.Plugin.Listenbrainz/Models/Musicbrainz/Recording.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Models/Musicbrainz/Recording.cs
@@ -1,3 +1,7 @@
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Text.Json.Serialization;
+
 namespace Jellyfin.Plugin.Listenbrainz.Models.Musicbrainz;
 
 /// <summary>
@@ -11,6 +15,7 @@ public class Recording
     public Recording()
     {
         Id = string.Empty;
+        ArtistCredit = new Collection<ArtistCredit>();
     }
 
     /// <summary>
@@ -22,4 +27,52 @@ public class Recording
     /// Gets or sets recording match score.
     /// </summary>
     public int Score { get; set; }
+
+    /// <summary>
+    /// Gets or sets artist credit of the recording.
+    /// </summary>
+    [JsonPropertyName("artist-credit")]
+    public Collection<ArtistCredit> ArtistCredit { get; set; }
+
+    /// <summary>
+    /// Get full artist credit for the recording.
+    /// </summary>
+    /// <returns>Artist credit.</returns>
+    public string GetCreditString()
+    {
+        var credit = new StringBuilder();
+        foreach (var artistCredit in ArtistCredit)
+        {
+            credit.Append(artistCredit.Name);
+            credit.Append(artistCredit.JoinPhrase);
+        }
+
+        return credit.ToString();
+    }
+}
+
+/// <summary>
+/// Artist credit model.
+/// </summary>
+public class ArtistCredit
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArtistCredit"/> class.
+    /// </summary>
+    public ArtistCredit()
+    {
+        JoinPhrase = string.Empty;
+        Name = string.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets join phrase.
+    /// </summary>
+    [JsonPropertyName("Joinphrase")]
+    public string JoinPhrase { get; set; }
+
+    /// <summary>
+    /// Gets or sets name.
+    /// </summary>
+    public string Name { get; set; }
 }


### PR DESCRIPTION
Send full artist credit as artist name in submitted Listens.

Metadata in Jellyfin:
<img width="372" alt="Screenshot 2022-07-05 at 20 25 47" src="https://user-images.githubusercontent.com/26324629/177393166-402c65ac-8dc0-4580-96f6-adb9ce76c052.png">

Before (only the first artist is sent):
<img width="374" alt="Screenshot 2022-07-05 at 20 25 38" src="https://user-images.githubusercontent.com/26324629/177393106-836ee22a-4f64-4bcc-abf5-6b6070877460.png">

After (all artists with correct join phrases):
<img width="497" alt="Screenshot 2022-07-05 at 20 26 31" src="https://user-images.githubusercontent.com/26324629/177393130-9c73b684-b79e-4ffe-b005-a1447e37cf10.png">


Since Jellyfin does not provide enough data to get the full credit in the correct intended format, the info is fetched from MusicBrainz, same as with recording IDs.

From: #10 