### PR TITLE
Fix too long sleep duration in retry logic

### DIFF
--- a/Jellyfin.Plugin.Listenbrainz/Clients/BaseHttpClient.cs
+++ b/Jellyfin.Plugin.Listenbrainz/Clients/BaseHttpClient.cs
@@ -81,7 +81,7 @@ public class BaseHttpClient
 
             retrySecs *= RetryBackoffSeconds;
             _logger.LogWarning("Request failed, will retry after {Num} seconds ({RequestID})", retrySecs, requestId);
-            _sleepService.Sleep(retrySecs * 1000);
+            _sleepService.Sleep(retrySecs);
         }
 
         if (response == null)


### PR DESCRIPTION
ISleepService expects a sleep duration in seconds, thus we don't need to multiply by 1000 here.