### PR TITLE
Unconfigured Musicbrainz integration should be enabled

### DIFF
--- a/Jellyfin.Plugin.Listenbrainz.JF108/Jellyfin.Plugin.Listenbrainz.JF108.csproj
+++ b/Jellyfin.Plugin.Listenbrainz.JF108/Jellyfin.Plugin.Listenbrainz.JF108.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Listenbrainz.JF108</RootNamespace>
-    <AssemblyVersion>2.2.0.7</AssemblyVersion>
-    <FileVersion>2.2.0.7</FileVersion>
+    <AssemblyVersion>2.2.1.0</AssemblyVersion>
+    <FileVersion>2.2.1.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Jellyfin.Plugin.Listenbrainz/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Listenbrainz/Configuration/configPage.html
@@ -300,7 +300,7 @@
 
                         if (gConfig?.MusicbrainzBaseUrl == null) {
                             gConfig.MusicbrainzBaseUrl = ListenbrainzConfig.globalConfigDefaults.MusicbrainzBaseUrl;
-                            gConfig.EnableMusicbrainz = ListenbrainzConfig.globalConfigDefaults.MusicbrainzEnabled;
+                            gConfig.MusicbrainzEnabled = ListenbrainzConfig.globalConfigDefaults.MusicbrainzEnabled;
                         }
 
                         ListenbrainzConfig.populateGlobalConfig(gConfig);

--- a/Jellyfin.Plugin.Listenbrainz/Jellyfin.Plugin.Listenbrainz.csproj
+++ b/Jellyfin.Plugin.Listenbrainz/Jellyfin.Plugin.Listenbrainz.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Listenbrainz</RootNamespace>
-    <AssemblyVersion>1.4.0.7</AssemblyVersion>
-    <FileVersion>1.4.0.7</FileVersion>
+    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <FileVersion>1.4.1.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
If there is no configuration for global entries, then the Musicbrainz integration should be enabled by default.