### PR TITLE
Remove -f parameters from build commands

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,8 +30,7 @@ jobs:
         run: |
           dotnet publish \
           -c Release \
-          -o artifacts/ \
-          -f net6.0
+          -o artifacts/
 
       - name: Upload plugin binary
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,7 @@ jobs:
         run: |
           dotnet publish \
           -c Release \
-          -o artifacts/ \
-          -f net6.0
+          -o artifacts/
 
       - name: Create ZIP archive
         working-directory: ./Jellyfin.Plugin.Listenbrainz/artifacts


### PR DESCRIPTION
Remove -f parameters to hopefully improve stability of build jobs.