### PR TITLE
Some small plugin tweaks

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -198,8 +198,8 @@ public class PluginImplementation
             return;
         }
 
-        var metadata = GetAdditionalMetadata(data);
         var now = DateUtils.CurrentTimestamp;
+        var metadata = GetAdditionalMetadata(data);
         try
         {
             _listenBrainzClient.SendListen(userConfig, data.Item, metadata, now);
@@ -289,8 +289,8 @@ public class PluginImplementation
             Monitor.Exit(_userDataSaveLock);
         }
 
-        var metadata = GetAdditionalMetadata(data);
         var now = DateUtils.CurrentTimestamp;
+        var metadata = GetAdditionalMetadata(data);
         try
         {
             _listenBrainzClient.SendListen(userConfig, data.Item, metadata, now);

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -117,13 +117,13 @@ public class ResubmitListensTask : IScheduledTask
     {
         var user = _userManager.GetUserById(userId);
         if (user is null) throw new PluginException("Invalid jellyfin user ID");
+        var userConfig = user.GetListenBrainzConfig();
+        if (userConfig is null) throw new PluginException($"No configuration for user {user.Username}");
+
         var listenChunks = _cacheManager.GetListens(userId).Chunk(Limits.MaxListensPerRequest);
         foreach (var listenChunk in listenChunks)
         {
             var chunkToSubmit = pluginConfig.IsMusicBrainzEnabled ? listenChunk.Select(UpdateMetadataIfNecessary) : listenChunk;
-            var userConfig = user.GetListenBrainzConfig();
-            if (userConfig is null) throw new PluginException($"No configuration for user {user.Username}");
-
             try
             {
                 _listenBrainzClient.SendListens(userConfig, chunkToSubmit);

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.ListenBrainz.Api.Resources;
+using Jellyfin.Plugin.ListenBrainz.Configuration;
 using Jellyfin.Plugin.ListenBrainz.Dtos;
 using Jellyfin.Plugin.ListenBrainz.Exceptions;
 using Jellyfin.Plugin.ListenBrainz.Extensions;
@@ -69,7 +70,7 @@ public class ResubmitListensTask : IScheduledTask
                         "Found listens in cache for user {UserId}, will try resubmitting",
                         userConfig.JellyfinUserId);
                     cancellationToken.ThrowIfCancellationRequested();
-                    SubmitListensForUser(userConfig.JellyfinUserId);
+                    SubmitListensForUser(config, userConfig.JellyfinUserId);
                 }
                 else
                 {
@@ -112,14 +113,14 @@ public class ResubmitListensTask : IScheduledTask
         return TimeSpan.TicksPerDay + (randomMinute * TimeSpan.TicksPerMinute);
     }
 
-    private void SubmitListensForUser(Guid userId)
+    private void SubmitListensForUser(PluginConfiguration pluginConfig, Guid userId)
     {
         var user = _userManager.GetUserById(userId);
         if (user is null) throw new PluginException("Invalid jellyfin user ID");
         var listenChunks = _cacheManager.GetListens(userId).Chunk(Limits.MaxListensPerRequest);
         foreach (var listenChunk in listenChunks)
         {
-            var chunkToSubmit = listenChunk.Select(UpdateMetadataIfNecessary);
+            var chunkToSubmit = pluginConfig.IsMusicBrainzEnabled ? listenChunk.Select(UpdateMetadataIfNecessary) : listenChunk;
             var userConfig = user.GetListenBrainzConfig();
             if (userConfig is null) throw new PluginException($"No configuration for user {user.Username}");
 


### PR DESCRIPTION
Getting the timestamp before the metadata request makes it a bit more accurate, if, for some reason, the MusicBrainz request takes a while (or even timeouts).

External metadata should only be requested from MusicBrainz on resubmission if enabled, to be consistent with the normal operation.

Lastly, the user data can be queried once instead of in every loop iteration.