### PR TITLE
Fix failing resubmit job due to missing file

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "3.1.0.1"
+version: "3.1.1.0"
 targetAbi: "10.8.0.0"
 framework: "net6.0"
 overview: "Track your music habits with ListenBrainz."
@@ -15,8 +15,5 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.Api.dll"
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
-  New
-    - Select which libraries to exclude from submitting listens (#41 @lyarenei)
-
-  Maintenance
-    - Improvements to submit and resubmit process (#46 @Maxr1998)
+  Fix
+    - Failing resubmit job (create cache file on first ever init) (#48 @lyarenei)

--- a/src/Jellyfin.Plugin.ListenBrainz/Managers/CacheManager.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Managers/CacheManager.cs
@@ -49,7 +49,15 @@ public class CacheManager : ICacheManager, IListensCache
     {
         get
         {
-            if (_instance is null) _instance = new CacheManager(Path.Join(Plugin.GetDataPath(), CacheFileName));
+            if (_instance is not null) return _instance;
+
+            var path = Path.Join(Plugin.GetDataPath(), CacheFileName);
+            _instance = new CacheManager(path);
+            if (!File.Exists(path))
+            {
+                _instance.Save();
+            }
+
             return _instance;
         }
     }


### PR DESCRIPTION
The resubmit job will keep failing if no listens have been cached since it would not trigger saving => creating the json file.

To fix this, if the file does not exist, it will be created by calling `Save()` method on cache instance init.