### PR TITLE
Use dependency injection for ListenBrainz API client

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -12,7 +12,7 @@ namespace Jellyfin.Plugin.ListenBrainz.Api;
 /// <summary>
 /// Base ListenBrainz API client.
 /// </summary>
-public class BaseClient
+public class BaseApiClient : IBaseApiClient
 {
     /// <summary>
     /// Serializer settings.
@@ -28,25 +28,18 @@ public class BaseClient
     private readonly ILogger _logger;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="BaseClient"/> class.
+    /// Initializes a new instance of the <see cref="BaseApiClient"/> class.
     /// </summary>
     /// <param name="client">Underlying HTTP client.</param>
     /// <param name="logger">Logger instance.</param>
-    public BaseClient(IHttpClient client, ILogger logger)
+    public BaseApiClient(IHttpClient client, ILogger logger)
     {
         _client = client;
         _logger = logger;
     }
 
-    /// <summary>
-    /// Send a POST request to the ListenBrainz server.
-    /// </summary>
-    /// <param name="request">The request to send.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <typeparam name="TRequest">Data type of the request.</typeparam>
-    /// <typeparam name="TResponse">Data type of the response.</typeparam>
-    /// <returns>Request response.</returns>
-    public async Task<TResponse?> Post<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+    /// <inheritdoc />
+    public async Task<TResponse?> SendPostRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
         where TRequest : IListenBrainzRequest
         where TResponse : IListenBrainzResponse
     {
@@ -62,15 +55,8 @@ public class BaseClient
         using (requestMessage) return await DoRequest<TResponse>(requestMessage, cancellationToken);
     }
 
-    /// <summary>
-    /// Send a GET request to the ListenBrainz server.
-    /// </summary>
-    /// <param name="request">The request to send.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <typeparam name="TRequest">Data type of the request.</typeparam>
-    /// <typeparam name="TResponse">Data type of the response.</typeparam>
-    /// <returns>Request response.</returns>
-    public async Task<TResponse?> Get<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+    /// <inheritdoc />
+    public async Task<TResponse?> SendGetRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
         where TRequest : IListenBrainzRequest
         where TResponse : IListenBrainzResponse
     {

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/HttpClientWrapper.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/HttpClientWrapper.cs
@@ -1,0 +1,24 @@
+using Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
+
+namespace Jellyfin.Plugin.ListenBrainz.Api;
+
+/// <inheritdoc />
+public class HttpClientWrapper : IHttpClient
+{
+    private readonly Http.HttpClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpClientWrapper"/> class.
+    /// </summary>
+    /// <param name="client">Underlying HTTP client.</param>
+    public HttpClientWrapper(Http.HttpClient client)
+    {
+        _client = client;
+    }
+
+    /// <inheritdoc />
+    public Task<HttpResponseMessage> SendRequest(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return _client.SendRequest(request, cancellationToken);
+    }
+}

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IBaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IBaseApiClient.cs
@@ -1,0 +1,31 @@
+namespace Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
+
+/// <summary>
+/// Base ListenBrainz API client.
+/// </summary>
+public interface IBaseApiClient
+{
+    /// <summary>
+    /// Send a POST request to the ListenBrainz server.
+    /// </summary>
+    /// <param name="request">The request to send.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <typeparam name="TRequest">Data type of the request.</typeparam>
+    /// <typeparam name="TResponse">Data type of the response.</typeparam>
+    /// <returns>Request response.</returns>
+    public Task<TResponse?> SendPostRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+        where TRequest : IListenBrainzRequest
+        where TResponse : IListenBrainzResponse;
+
+    /// <summary>
+    /// Send a GET request to the ListenBrainz server.
+    /// </summary>
+    /// <param name="request">The request to send.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <typeparam name="TRequest">Data type of the request.</typeparam>
+    /// <typeparam name="TResponse">Data type of the response.</typeparam>
+    /// <returns>Request response.</returns>
+    public Task<TResponse?> SendGetRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+        where TRequest : IListenBrainzRequest
+        where TResponse : IListenBrainzResponse;
+}

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IHttpClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IHttpClient.cs
@@ -1,0 +1,15 @@
+namespace Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
+
+/// <summary>
+/// HttpClient used by the ListenBrainz base API client.
+/// </summary>
+public interface IHttpClient
+{
+    /// <summary>
+    /// Send a HTTP request.
+    /// </summary>
+    /// <param name="request">Request to send.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Task with <see cref="HttpResponseMessage"/> result.</returns>
+    public Task<HttpResponseMessage> SendRequest(HttpRequestMessage request, CancellationToken cancellationToken);
+}

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
@@ -1,7 +1,6 @@
 using Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
 using Jellyfin.Plugin.ListenBrainz.Api.Models.Requests;
 using Jellyfin.Plugin.ListenBrainz.Api.Models.Responses;
-using Jellyfin.Plugin.ListenBrainz.Http.Interfaces;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.ListenBrainz.Api;
@@ -9,37 +8,37 @@ namespace Jellyfin.Plugin.ListenBrainz.Api;
 /// <summary>
 /// ListenBrainz API client.
 /// </summary>
-public class ListenBrainzApiClient : BaseClient, IListenBrainzApiClient
+public class ListenBrainzApiClient : IListenBrainzApiClient
 {
+    private readonly BaseClient _client;
+    private readonly ILogger _logger;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ListenBrainzApiClient"/> class.
     /// </summary>
-    /// <param name="httpClientFactory">HTTP client factory.</param>
+    /// <param name="client">Underlying base client.</param>
     /// <param name="logger">Logger instance.</param>
-    /// <param name="sleepService">Sleep service.</param>
-    public ListenBrainzApiClient(
-        IHttpClientFactory httpClientFactory,
-        ILogger logger,
-        ISleepService? sleepService = null)
-        : base(httpClientFactory, logger, sleepService)
+    public ListenBrainzApiClient(BaseClient client, ILogger logger)
     {
+        _client = client;
+        _logger = logger;
     }
 
     /// <inheritdoc />
     public async Task<ValidateTokenResponse?> ValidateToken(ValidateTokenRequest request, CancellationToken cancellationToken)
     {
-        return await Get<ValidateTokenRequest, ValidateTokenResponse>(request, cancellationToken);
+        return await _client.Get<ValidateTokenRequest, ValidateTokenResponse>(request, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<SubmitListensResponse?> SubmitListens(SubmitListensRequest request, CancellationToken cancellationToken)
     {
-        return await Post<SubmitListensRequest, SubmitListensResponse>(request, cancellationToken);
+        return await _client.Post<SubmitListensRequest, SubmitListensResponse>(request, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<RecordingFeedbackResponse?> SubmitRecordingFeedback(RecordingFeedbackRequest request, CancellationToken cancellationToken)
     {
-        return await Post<RecordingFeedbackRequest, RecordingFeedbackResponse>(request, cancellationToken);
+        return await _client.Post<RecordingFeedbackRequest, RecordingFeedbackResponse>(request, cancellationToken);
     }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
@@ -10,35 +10,35 @@ namespace Jellyfin.Plugin.ListenBrainz.Api;
 /// </summary>
 public class ListenBrainzApiClient : IListenBrainzApiClient
 {
-    private readonly BaseClient _client;
+    private readonly IBaseApiClient _apiClient;
     private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ListenBrainzApiClient"/> class.
     /// </summary>
-    /// <param name="client">Underlying base client.</param>
+    /// <param name="apiClient">Underlying base client.</param>
     /// <param name="logger">Logger instance.</param>
-    public ListenBrainzApiClient(BaseClient client, ILogger logger)
+    public ListenBrainzApiClient(IBaseApiClient apiClient, ILogger logger)
     {
-        _client = client;
+        _apiClient = apiClient;
         _logger = logger;
     }
 
     /// <inheritdoc />
     public async Task<ValidateTokenResponse?> ValidateToken(ValidateTokenRequest request, CancellationToken cancellationToken)
     {
-        return await _client.Get<ValidateTokenRequest, ValidateTokenResponse>(request, cancellationToken);
+        return await _apiClient.SendGetRequest<ValidateTokenRequest, ValidateTokenResponse>(request, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<SubmitListensResponse?> SubmitListens(SubmitListensRequest request, CancellationToken cancellationToken)
     {
-        return await _client.Post<SubmitListensRequest, SubmitListensResponse>(request, cancellationToken);
+        return await _apiClient.SendPostRequest<SubmitListensRequest, SubmitListensResponse>(request, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<RecordingFeedbackResponse?> SubmitRecordingFeedback(RecordingFeedbackRequest request, CancellationToken cancellationToken)
     {
-        return await _client.Post<RecordingFeedbackRequest, RecordingFeedbackResponse>(request, cancellationToken);
+        return await _apiClient.SendPostRequest<RecordingFeedbackRequest, RecordingFeedbackResponse>(request, cancellationToken);
     }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Http/HttpClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Http/HttpClient.cs
@@ -34,7 +34,7 @@ public class HttpClient
     /// <param name="httpClientFactory">HTTP client factory.</param>
     /// <param name="logger">Logger instance.</param>
     /// <param name="sleepService">Sleep service.</param>
-    protected HttpClient(IHttpClientFactory httpClientFactory, ILogger logger, ISleepService? sleepService)
+    public HttpClient(IHttpClientFactory httpClientFactory, ILogger logger, ISleepService? sleepService)
     {
         _httpClientFactory = httpClientFactory;
         _logger = logger;
@@ -49,7 +49,7 @@ public class HttpClient
     /// <returns>Request response.</returns>
     /// <exception cref="RetryException">Number of retries has been reached.</exception>
     /// <exception cref="InvalidResponseException">Response is not available.</exception>
-    protected async Task<HttpResponseMessage> SendRequest(
+    public async Task<HttpResponseMessage> SendRequest(
         HttpRequestMessage requestMessage,
         CancellationToken cancellationToken)
     {

--- a/src/Jellyfin.Plugin.ListenBrainz/Utils/ClientUtils.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Utils/ClientUtils.cs
@@ -5,7 +5,6 @@ using Jellyfin.Plugin.ListenBrainz.Interfaces;
 using Jellyfin.Plugin.ListenBrainz.MusicBrainzApi;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
-using BaseClient = Jellyfin.Plugin.ListenBrainz.Api.BaseClient;
 using UnderlyingClient = Jellyfin.Plugin.ListenBrainz.Http.HttpClient;
 
 namespace Jellyfin.Plugin.ListenBrainz.Utils;
@@ -28,7 +27,7 @@ public static class ClientUtils
         ILibraryManager? libraryManager = null)
     {
         var httpClient = new UnderlyingClient(clientFactory, logger, null);
-        var baseClient = new BaseClient(new HttpClientWrapper(httpClient), logger);
+        var baseClient = new BaseApiClient(new HttpClientWrapper(httpClient), logger);
         var apiClient = new ListenBrainzApiClient(baseClient, logger);
         return libraryManager is null ? new ListenBrainzClient(logger, apiClient) : new ListenBrainzClient(logger, apiClient, libraryManager);
     }

--- a/src/Jellyfin.Plugin.ListenBrainz/Utils/ClientUtils.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Utils/ClientUtils.cs
@@ -5,6 +5,8 @@ using Jellyfin.Plugin.ListenBrainz.Interfaces;
 using Jellyfin.Plugin.ListenBrainz.MusicBrainzApi;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
+using BaseClient = Jellyfin.Plugin.ListenBrainz.Api.BaseClient;
+using UnderlyingClient = Jellyfin.Plugin.ListenBrainz.Http.HttpClient;
 
 namespace Jellyfin.Plugin.ListenBrainz.Utils;
 
@@ -25,7 +27,9 @@ public static class ClientUtils
         IHttpClientFactory clientFactory,
         ILibraryManager? libraryManager = null)
     {
-        var apiClient = new ListenBrainzApiClient(clientFactory, logger);
+        var httpClient = new UnderlyingClient(clientFactory, logger, null);
+        var baseClient = new BaseClient(new HttpClientWrapper(httpClient), logger);
+        var apiClient = new ListenBrainzApiClient(baseClient, logger);
         return libraryManager is null ? new ListenBrainzClient(logger, apiClient) : new ListenBrainzClient(logger, apiClient, libraryManager);
     }
 

--- a/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/JsonEncodeTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/JsonEncodeTests.cs
@@ -27,7 +27,7 @@ public class ListenTests
     [Fact]
     public void Listen_Encode()
     {
-        var listenJson = JsonConvert.SerializeObject(_exampleListen, BaseClient.SerializerSettings);
+        var listenJson = JsonConvert.SerializeObject(_exampleListen, BaseApiClient.SerializerSettings);
         Assert.NotNull(listenJson);
 
         var expectedJSON = @"{""listened_at"":1234,""track_metadata"":{""artist_name"":""Foo Bar"",""track_name"":""Foo - Bar"",""release_name"":""Foobar"",""additional_info"":{""artist_mbids"":[""artist-foo""],""release_mbid"":""release-foo"",""recording_mbid"":""recording-foo""}}}";
@@ -37,8 +37,8 @@ public class ListenTests
     [Fact]
     public void Listen_EncodeAndDecode()
     {
-        var listenJson = JsonConvert.SerializeObject(_exampleListen, BaseClient.SerializerSettings);
-        var deserializedListen = JsonConvert.DeserializeObject<Listen>(listenJson, BaseClient.SerializerSettings);
+        var listenJson = JsonConvert.SerializeObject(_exampleListen, BaseApiClient.SerializerSettings);
+        var deserializedListen = JsonConvert.DeserializeObject<Listen>(listenJson, BaseApiClient.SerializerSettings);
         Assert.NotNull(deserializedListen);
     }
 }
@@ -52,7 +52,7 @@ public class RecordingFeedbackTests
     public void FeedbackValues_Encode(FeedbackScore score)
     {
         var request = new RecordingFeedbackRequest { Score = score };
-        var actualJson = JsonConvert.SerializeObject(request, BaseClient.SerializerSettings);
+        var actualJson = JsonConvert.SerializeObject(request, BaseApiClient.SerializerSettings);
         Assert.NotNull(actualJson);
 
         var expectedJson = @"{""score"":" + (int)score + "}";


### PR DESCRIPTION
Replace subclassing with dependency injection to make the clients more testable.

Blocks #53 