### PR TITLE
Send ISRC in additional info

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Models/Recording.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Models/Recording.cs
@@ -14,6 +14,7 @@ public class Recording
     {
         Mbid = string.Empty;
         ArtistCredits = new List<ArtistCredit>();
+        Isrcs = new List<string>();
     }
 
     /// <summary>
@@ -32,4 +33,9 @@ public class Recording
     /// </summary>
     [JsonPropertyName("artist-credit")]
     public IEnumerable<ArtistCredit> ArtistCredits { get; set; }
+
+    /// <summary>
+    /// Gets or sets ISRCs associated with this recording.
+    /// </summary>
+    public IEnumerable<string> Isrcs { get; set; }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Models/Recording.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Models/Recording.cs
@@ -12,8 +12,8 @@ public class Recording
     /// </summary>
     public Recording()
     {
-        this.Mbid = string.Empty;
-        this.ArtistCredits = new List<ArtistCredit>();
+        Mbid = string.Empty;
+        ArtistCredits = new List<ArtistCredit>();
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.ListenBrainz/Dtos/AudioItemMetadata.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Dtos/AudioItemMetadata.cs
@@ -15,7 +15,8 @@ public class AudioItemMetadata
     public AudioItemMetadata()
     {
         RecordingMbid = string.Empty;
-        ArtistCredits = Array.Empty<ArtistCredit>();
+        ArtistCredits = new List<ArtistCredit>();
+        Isrcs = new List<string>();
     }
 
     /// <summary>
@@ -26,6 +27,7 @@ public class AudioItemMetadata
     {
         RecordingMbid = recording.Mbid;
         ArtistCredits = recording.ArtistCredits.Select(r => new ArtistCredit(r.Name, r.JoinPhrase));
+        Isrcs = recording.Isrcs;
     }
 
     /// <summary>
@@ -57,4 +59,9 @@ public class AudioItemMetadata
             return creditString.ToString();
         }
     }
+
+    /// <summary>
+    /// Gets or sets ISRCs associated with this audio item.
+    /// </summary>
+    public IEnumerable<string> Isrcs { get; set; }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
@@ -53,6 +53,7 @@ public static class AudioExtensions
                     TrackMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzTrack"),
                     WorkMbids = null,
                     TrackNumber = item.IndexNumber,
+                    Isrc = itemMetadata?.Isrcs.FirstOrDefault(),
                     Tags = item.Tags,
                     DurationMs = (item.RunTimeTicks / TimeSpan.TicksPerSecond) * 1000
                 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
@@ -54,7 +54,7 @@ public static class AudioExtensions
                     WorkMbids = null,
                     TrackNumber = item.IndexNumber,
                     Tags = item.Tags,
-                    DurationMs = (item.RunTimeTicks / TimeSpan.TicksPerSecond) * 1000,
+                    DurationMs = (item.RunTimeTicks / TimeSpan.TicksPerSecond) * 1000
                 }
             }
         };


### PR DESCRIPTION
Fetch ISRCs from MusicBrainz and include the first one in additional info when sending a listen to ListenBrainz.

Closes #66. 