### PR TITLE
Propagate errors from async methods and simplify LB API client

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -124,11 +124,17 @@ public class BaseApiClient : IBaseApiClient
             _gateway.Release();
         }
 
-        if (response is null) throw new InvalidResponseException("Response is NULL");
+        if (response is null)
+        {
+            throw new InvalidResponseException("No response is available");
+        }
 
         var stringContent = await response.Content.ReadAsStringAsync(cancellationToken);
         var result = JsonConvert.DeserializeObject<TResponse>(stringContent, SerializerSettings);
-        if (result is null) throw new InvalidResponseException("Response deserialized to NULL");
+        if (result is null)
+        {
+            throw new InvalidResponseException("Failed to parse JSON data from response");
+        }
 
         result.IsOk = response.IsSuccessStatusCode;
         return result;

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -50,7 +50,7 @@ public class BaseApiClient : IBaseApiClient
     }
 
     /// <inheritdoc />
-    public async Task<TResponse?> SendPostRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+    public async Task<TResponse> SendPostRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
         where TRequest : IListenBrainzRequest
         where TResponse : IListenBrainzResponse
     {
@@ -67,7 +67,7 @@ public class BaseApiClient : IBaseApiClient
     }
 
     /// <inheritdoc />
-    public async Task<TResponse?> SendGetRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+    public async Task<TResponse> SendGetRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
         where TRequest : IListenBrainzRequest
         where TResponse : IListenBrainzResponse
     {
@@ -85,7 +85,7 @@ public class BaseApiClient : IBaseApiClient
 
     private static Uri BuildRequestUri(string baseUrl, string endpoint) => new($"{baseUrl}/{General.Version}/{endpoint}");
 
-    private async Task<TResponse?> DoRequest<TResponse>(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
+    private async Task<TResponse> DoRequest<TResponse>(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
         where TResponse : IListenBrainzResponse
     {
         HttpResponseMessage? response = null;

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -24,6 +24,7 @@ public class BaseApiClient : IBaseApiClient, IDisposable
     private readonly SemaphoreSlim _gateway;
     private readonly ILogger _logger;
     private readonly ISleepService _sleepService;
+    private bool _isDisposed;
 
     /// <summary>
     /// Serializer settings.
@@ -47,6 +48,7 @@ public class BaseApiClient : IBaseApiClient, IDisposable
         _logger = logger;
         _sleepService = sleepService ?? new DefaultSleepService();
         _gateway = new SemaphoreSlim(1, 1);
+        _isDisposed = false;
     }
 
     /// <summary>
@@ -62,15 +64,22 @@ public class BaseApiClient : IBaseApiClient, IDisposable
     }
 
     /// <summary>
-    /// Disposes managed and native resources.
+    /// Disposes managed and unmanaged (own) resources.
     /// </summary>
     /// <param name="disposing">Dispose managed resources.</param>
     protected virtual void Dispose(bool disposing)
     {
+        if (_isDisposed)
+        {
+            return;
+        }
+
         if (disposing)
         {
             _gateway.Dispose();
         }
+
+        _isDisposed = true;
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -98,7 +98,7 @@ public class BaseApiClient : IBaseApiClient
         try
         {
             _logger.LogDebug("({Id}) Sending request...", correlationId);
-            response = await DoRequestWithRetry(requestMessage, cancellationToken, correlationId);
+            response = await DoRequestWithRetry(requestMessage, correlationId, cancellationToken);
         }
         finally
         {
@@ -122,7 +122,7 @@ public class BaseApiClient : IBaseApiClient
         return result;
     }
 
-    private async Task<HttpResponseMessage?> DoRequestWithRetry(HttpRequestMessage requestMessage, CancellationToken cancellationToken, string correlationId)
+    private async Task<HttpResponseMessage?> DoRequestWithRetry(HttpRequestMessage requestMessage, string correlationId, CancellationToken cancellationToken)
     {
         HttpResponseMessage? response = null;
         for (int i = 0; i < RateLimitAttempts; i++)

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -167,12 +167,12 @@ public class BaseApiClient : IBaseApiClient, IDisposable
         var resetIn = header.Value.FirstOrDefault();
         if (resetIn is null)
         {
-            throw new ListenBrainzException("No 'rate limit reset in' value available, cannot continue");
+            throw new ListenBrainzException("No 'rate limit reset in' header value available");
         }
 
         if (!int.TryParse(resetIn, out var resetInSec))
         {
-            throw new ListenBrainzException("Invalid value for 'rate limit reset in', cannot continue");
+            throw new ListenBrainzException("Invalid value for 'rate limit reset in' header");
         }
 
         _logger.LogDebug("Waiting for {Seconds} seconds before trying again", resetInSec);

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -49,6 +49,11 @@ public class BaseApiClient : IBaseApiClient, IDisposable
         _gateway = new SemaphoreSlim(1, 1);
     }
 
+    /// <summary>
+    /// Finalizes an instance of the <see cref="BaseApiClient"/> class.
+    /// </summary>
+    ~BaseApiClient() => Dispose(false);
+
     /// <inheritdoc />
     public void Dispose()
     {

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/BaseApiClient.cs
@@ -17,7 +17,7 @@ namespace Jellyfin.Plugin.ListenBrainz.Api;
 /// <summary>
 /// Base ListenBrainz API client.
 /// </summary>
-public class BaseApiClient : IBaseApiClient
+public class BaseApiClient : IBaseApiClient, IDisposable
 {
     private const int RateLimitAttempts = 50;
     private readonly IHttpClient _client;
@@ -47,6 +47,25 @@ public class BaseApiClient : IBaseApiClient
         _logger = logger;
         _sleepService = sleepService ?? new DefaultSleepService();
         _gateway = new SemaphoreSlim(1, 1);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes managed and native resources.
+    /// </summary>
+    /// <param name="disposing">Dispose managed resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _gateway.Dispose();
+        }
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IBaseApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IBaseApiClient.cs
@@ -13,7 +13,7 @@ public interface IBaseApiClient
     /// <typeparam name="TRequest">Data type of the request.</typeparam>
     /// <typeparam name="TResponse">Data type of the response.</typeparam>
     /// <returns>Request response.</returns>
-    public Task<TResponse?> SendPostRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+    public Task<TResponse> SendPostRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
         where TRequest : IListenBrainzRequest
         where TResponse : IListenBrainzResponse;
 
@@ -25,7 +25,7 @@ public interface IBaseApiClient
     /// <typeparam name="TRequest">Data type of the request.</typeparam>
     /// <typeparam name="TResponse">Data type of the response.</typeparam>
     /// <returns>Request response.</returns>
-    public Task<TResponse?> SendGetRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
+    public Task<TResponse> SendGetRequest<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken)
         where TRequest : IListenBrainzRequest
         where TResponse : IListenBrainzResponse;
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IListenBrainzApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IListenBrainzApiClient.cs
@@ -14,7 +14,7 @@ public interface IListenBrainzApiClient
     /// <param name="request">Validate token request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Request response.</returns>
-    public Task<ValidateTokenResponse?> ValidateToken(ValidateTokenRequest request, CancellationToken cancellationToken);
+    public Task<ValidateTokenResponse> ValidateToken(ValidateTokenRequest request, CancellationToken cancellationToken);
 
     /// <summary>
     /// Submit listens.
@@ -22,7 +22,7 @@ public interface IListenBrainzApiClient
     /// <param name="request">Submit listens request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Request response.</returns>
-    public Task<SubmitListensResponse?> SubmitListens(SubmitListensRequest request, CancellationToken cancellationToken);
+    public Task<SubmitListensResponse> SubmitListens(SubmitListensRequest request, CancellationToken cancellationToken);
 
     /// <summary>
     /// Submit a recording feedback.
@@ -30,7 +30,7 @@ public interface IListenBrainzApiClient
     /// <param name="request">Recording feedback request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Request response.</returns>
-    public Task<RecordingFeedbackResponse?> SubmitRecordingFeedback(RecordingFeedbackRequest request, CancellationToken cancellationToken);
+    public Task<RecordingFeedbackResponse> SubmitRecordingFeedback(RecordingFeedbackRequest request, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get listens of a specified user.
@@ -38,5 +38,5 @@ public interface IListenBrainzApiClient
     /// <param name="request">User listens request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Request response.</returns>
-    public Task<GetUserListensResponse?> GetUserListens(GetUserListensRequest request, CancellationToken cancellationToken);
+    public Task<GetUserListensResponse> GetUserListens(GetUserListensRequest request, CancellationToken cancellationToken);
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IListenBrainzResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IListenBrainzResponse.cs
@@ -17,5 +17,5 @@ public interface IListenBrainzResponse
     /// Gets a value indicating whether response is not OK.
     /// </summary>
     [JsonIgnore]
-    public virtual bool IsNotOk => !IsOk;
+    public bool IsNotOk => !IsOk;
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
@@ -25,25 +25,25 @@ public class ListenBrainzApiClient : IListenBrainzApiClient
     }
 
     /// <inheritdoc />
-    public async Task<ValidateTokenResponse?> ValidateToken(ValidateTokenRequest request, CancellationToken cancellationToken)
+    public async Task<ValidateTokenResponse> ValidateToken(ValidateTokenRequest request, CancellationToken cancellationToken)
     {
         return await _apiClient.SendGetRequest<ValidateTokenRequest, ValidateTokenResponse>(request, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<SubmitListensResponse?> SubmitListens(SubmitListensRequest request, CancellationToken cancellationToken)
+    public async Task<SubmitListensResponse> SubmitListens(SubmitListensRequest request, CancellationToken cancellationToken)
     {
         return await _apiClient.SendPostRequest<SubmitListensRequest, SubmitListensResponse>(request, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<RecordingFeedbackResponse?> SubmitRecordingFeedback(RecordingFeedbackRequest request, CancellationToken cancellationToken)
+    public async Task<RecordingFeedbackResponse> SubmitRecordingFeedback(RecordingFeedbackRequest request, CancellationToken cancellationToken)
     {
         return await _apiClient.SendPostRequest<RecordingFeedbackRequest, RecordingFeedbackResponse>(request, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<GetUserListensResponse?> GetUserListens(GetUserListensRequest request, CancellationToken cancellationToken)
+    public async Task<GetUserListensResponse> GetUserListens(GetUserListensRequest request, CancellationToken cancellationToken)
     {
         return await _apiClient.SendGetRequest<GetUserListensRequest, GetUserListensResponse>(request, cancellationToken);
     }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/GetUserListensResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/GetUserListensResponse.cs
@@ -18,6 +18,9 @@ public class GetUserListensResponse : IListenBrainzResponse
     /// <inheritdoc />
     public bool IsOk { get; set; }
 
+    /// <inheritdoc />
+    public bool IsNotOk => !IsOk;
+
     /// <summary>
     /// Gets or sets response payload.
     /// </summary>

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/RecordingFeedbackResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/RecordingFeedbackResponse.cs
@@ -9,4 +9,7 @@ public class RecordingFeedbackResponse : IListenBrainzResponse
 {
     /// <inheritdoc />
     public bool IsOk { get; set; }
+
+    /// <inheritdoc />
+    public bool IsNotOk => !IsOk;
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/SubmitListensResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/SubmitListensResponse.cs
@@ -9,4 +9,7 @@ public class SubmitListensResponse : IListenBrainzResponse
 {
     /// <inheritdoc />
     public bool IsOk { get; set; }
+
+    /// <inheritdoc />
+    public bool IsNotOk => !IsOk;
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/ValidateTokenResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/ValidateTokenResponse.cs
@@ -20,6 +20,9 @@ public class ValidateTokenResponse : IListenBrainzResponse
     /// <inheritdoc />
     public bool IsOk { get; set; }
 
+    /// <inheritdoc />
+    public bool IsNotOk => !IsOk;
+
     /// <summary>
     /// Gets or sets status code.
     /// </summary>

--- a/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
@@ -64,6 +64,11 @@ public class ListenBrainzClient : IListenBrainzClient
         {
             throw task.Exception;
         }
+
+        if (task.Result.IsNotOk)
+        {
+            throw new PluginException("Sending now playing failed");
+        }
     }
 
     /// <inheritdoc />
@@ -83,6 +88,11 @@ public class ListenBrainzClient : IListenBrainzClient
         if (task.Exception is not null)
         {
             throw task.Exception;
+        }
+
+        if (task.Result.IsNotOk)
+        {
+            throw new PluginException("Sending listen failed");
         }
     }
 
@@ -105,6 +115,11 @@ public class ListenBrainzClient : IListenBrainzClient
         {
             throw task.Exception;
         }
+
+        if (task.Result.IsNotOk)
+        {
+            throw new PluginException("Sending feedback failed");
+        }
     }
 
     /// <inheritdoc />
@@ -124,6 +139,11 @@ public class ListenBrainzClient : IListenBrainzClient
         if (task.Exception is not null)
         {
             throw task.Exception;
+        }
+
+        if (task.Result.IsNotOk)
+        {
+            throw new PluginException("Sending listens failed");
         }
     }
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
@@ -58,7 +58,12 @@ public class ListenBrainzClient : IListenBrainzClient
             BaseUrl = pluginConfig.ListenBrainzApiUrl
         };
 
-        _apiClient.SubmitListens(request, CancellationToken.None);
+        var task = _apiClient.SubmitListens(request, CancellationToken.None);
+        task.Wait();
+        if (task.Exception is not null)
+        {
+            throw task.Exception;
+        }
     }
 
     /// <inheritdoc />
@@ -73,7 +78,12 @@ public class ListenBrainzClient : IListenBrainzClient
             BaseUrl = pluginConfig.ListenBrainzApiUrl
         };
 
-        _apiClient.SubmitListens(request, CancellationToken.None);
+        var task = _apiClient.SubmitListens(request, CancellationToken.None);
+        task.Wait();
+        if (task.Exception is not null)
+        {
+            throw task.Exception;
+        }
     }
 
     /// <inheritdoc />
@@ -89,7 +99,12 @@ public class ListenBrainzClient : IListenBrainzClient
             BaseUrl = pluginConfig.ListenBrainzApiUrl
         };
 
-        _apiClient.SubmitRecordingFeedback(request, CancellationToken.None);
+        var task = _apiClient.SubmitRecordingFeedback(request, CancellationToken.None);
+        task.Wait();
+        if (task.Exception is not null)
+        {
+            throw task.Exception;
+        }
     }
 
     /// <inheritdoc />
@@ -104,7 +119,12 @@ public class ListenBrainzClient : IListenBrainzClient
             BaseUrl = pluginConfig.ListenBrainzApiUrl
         };
 
-        _apiClient.SubmitListens(request, CancellationToken.None);
+        var task = _apiClient.SubmitListens(request, CancellationToken.None);
+        task.Wait();
+        if (task.Exception is not null)
+        {
+            throw task.Exception;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
@@ -153,7 +153,6 @@ public class ListenBrainzClient : IListenBrainzClient
         var pluginConfig = Plugin.GetConfiguration();
         var request = new ValidateTokenRequest(apiToken) { BaseUrl = pluginConfig.ListenBrainzApiUrl };
         var response = await _apiClient.ValidateToken(request, CancellationToken.None);
-        if (response is null) throw new PluginException("Did not receive response");
         return new ValidatedToken
         {
             IsValid = response.Valid,
@@ -175,11 +174,6 @@ public class ListenBrainzClient : IListenBrainzClient
 
         var request = new GetUserListensRequest(userName);
         var response = await _apiClient.GetUserListens(request, CancellationToken.None);
-        if (response is null)
-        {
-            throw new PluginException("Did not receive response for user listens request");
-        }
-
         return response.Payload.Listens.FirstOrDefault(l => l.ListenedAt == ts)?.RecordingMsid;
     }
 
@@ -208,14 +202,10 @@ public class ListenBrainzClient : IListenBrainzClient
     /// <returns>ListenBrainz username associated with the API token.</returns>
     /// <exception cref="PluginException">Username could not be obtained.</exception>
     private async Task<string> GetListenBrainzUsername(string userApiToken)
-    {var pluginConfig = Plugin.GetConfiguration();
+    {
+        var pluginConfig = Plugin.GetConfiguration();
         var tokenRequest = new ValidateTokenRequest(userApiToken) { BaseUrl = pluginConfig.ListenBrainzApiUrl };
         var tokenResponse = await _apiClient.ValidateToken(tokenRequest, CancellationToken.None);
-        if (tokenResponse is null)
-        {
-            throw new PluginException("Did not receive response for token validate request");
-        }
-
         if (tokenResponse.UserName is null)
         {
             throw new PluginException("ValidateToken response does not contain username");

--- a/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
@@ -145,10 +145,11 @@ public class ListenBrainzClient : IListenBrainzClient
     /// <inheritdoc />
     public async Task<string?> GetRecordingMsidByListenTs(UserConfig config, long ts)
     {
-        // Earlier 3.x plugin configurations did not store the username
         var userName = config.UserName;
         if (string.IsNullOrEmpty(userName))
         {
+            // Earlier 3.x plugin configurations did not store the username
+            _logger.LogDebug("ListenBrainz username is not available, getting it via token validation");
             userName = await GetListenBrainzUsername(config.PlaintextApiToken);
         }
 
@@ -189,8 +190,6 @@ public class ListenBrainzClient : IListenBrainzClient
     private async Task<string> GetListenBrainzUsername(string userApiToken)
     {var pluginConfig = Plugin.GetConfiguration();
         var tokenRequest = new ValidateTokenRequest(userApiToken) { BaseUrl = pluginConfig.ListenBrainzApiUrl };
-        _logger.LogDebug("ListenBrainz username is not available, getting it via token validation");
-
         var tokenResponse = await _apiClient.ValidateToken(tokenRequest, CancellationToken.None);
         if (tokenResponse is null)
         {

--- a/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListenBrainzClient.cs
@@ -15,6 +15,7 @@ public interface IListenBrainzClient
     /// <param name="config">ListenBrainz user configuration.</param>
     /// <param name="item">Audio item currently being listened to.</param>
     /// <param name="audioMetadata">Additional metadata for this audio item.</param>
+    /// <exception cref="AggregateException">Sending failed.</exception>
     public void SendNowPlaying(UserConfig config, Audio item, AudioItemMetadata? audioMetadata);
 
     /// <summary>
@@ -24,6 +25,7 @@ public interface IListenBrainzClient
     /// <param name="item">Audio item of the listen.</param>
     /// <param name="metadata">Additional metadata for this audio item.</param>
     /// <param name="listenedAt">Timestamp of the listen.</param>
+    /// <exception cref="AggregateException">Sending failed.</exception>
     public void SendListen(UserConfig config, Audio item, AudioItemMetadata? metadata, long listenedAt);
 
     /// <summary>
@@ -33,6 +35,7 @@ public interface IListenBrainzClient
     /// <param name="isFavorite">The recording is marked as favorite.</param>
     /// <param name="recordingMbid">MusicBrainz ID identifying the recording.</param>
     /// <param name="recordingMsid">MessyBrainz ID identifying the recording.</param>
+    /// <exception cref="AggregateException">Sending failed.</exception>
     public void SendFeedback(UserConfig config, bool isFavorite, string? recordingMbid = null, string? recordingMsid = null);
 
     /// <summary>
@@ -40,6 +43,7 @@ public interface IListenBrainzClient
     /// </summary>
     /// <param name="config">ListenBrainz user configuration.</param>
     /// <param name="storedListens">Listens to send.</param>
+    /// <exception cref="AggregateException">Sending failed.</exception>
     public void SendListens(UserConfig config, IEnumerable<StoredListen> storedListens);
 
     /// <summary>


### PR DESCRIPTION
Fix calling asynchronous methods from synchronous methods so the exceptions are propagated correctly. Also simplify the client interface and handle more error states.

Closes #70 