### PR TITLE
Immediate favorite sync

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -77,6 +77,9 @@ Currently used metadata from MusicBrainz:
   In some cases, there may be multiple ISRCs stored in MusicBrainz for a specific recording. In these cases, the plugin
   simply chooses the first one.
 
+- **Immediate favorite sync**
+  Enabling this integration allows you to use this feature, as it relies on the `Recording MBID`.
+
 ##### Use alternative event for recognizing listens
 
 The plugin can work in two distinct modes of listen recognition.
@@ -124,10 +127,9 @@ same timestamp.
 
 ##### Immediate favorite sync
 
-Controls the behavior of favorite sync feature. If enabled, the favorite status of a track is synced immediately to
-ListenBrainz, in addition to syncing after playback of the track is finished.
-
-This feature also requires the MusicBrainz integration as this is only possible by sending a `Recording MBID` of the track.
+Modifies the behavior of favorite sync feature. If enabled, the favorite status of a track is synced immediately to
+ListenBrainz. Standard favorite sync (after playback of track finishes) is not affected. This feature only works if
+track has required metadata (track MBID) and the MusicBrainz integration is enabled.
 
 ##### Allowed libraries for listen submission
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -122,6 +122,13 @@ conditions. In such cases, the plugin will default to current time. This should 
 client does not specify times when reporting playbacks retroactively, all listens reported in that time will have the
 same timestamp.
 
+##### Immediate favorite sync
+
+Controls the behavior of favorite sync feature. If enabled, the favorite status of a track is synced immediately to
+ListenBrainz, in addition to syncing after playback of the track is finished.
+
+This feature also requires the MusicBrainz integration as this is only possible by sending a `Recording MBID` of the track.
+
 ##### Allowed libraries for listen submission
 
 Depending on your setup, you may not want to record listens of audio from a certain library. Listens of audio from

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/PluginConfiguration.cs
@@ -14,6 +14,7 @@ public class PluginConfiguration : BasePluginConfiguration
     private string? _listenBrainzUrlOverride;
     private bool? _isMusicBrainzEnabledOverride;
     private bool? _isAlternativeModeEnabled;
+    private bool? _isImmediateFavoriteSyncEnabled;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
@@ -70,6 +71,15 @@ public class PluginConfiguration : BasePluginConfiguration
     {
         get => _isAlternativeModeEnabled ?? false;
         set => _isAlternativeModeEnabled = value;
+    }
+
+    /// <summary>
+    /// Gets or set a value indicating whether immediate favorite sync is enabled.
+    /// </summary>
+    public bool IsImmediateFavoriteSyncEnabled
+    {
+        get => _isImmediateFavoriteSyncEnabled ?? true;
+        set => _isImmediateFavoriteSyncEnabled = value;
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/configurationPage.html
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/configurationPage.html
@@ -113,6 +113,14 @@
                             </label>
                             <div class="fieldDescription">Requires clients to mark items as played.</div>
                         </div>
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="IsImmediateFavoriteSyncEnabled">
+                                <input is="emby-checkbox" type="checkbox" id="IsImmediateFavoriteSyncEnabled"
+                                       name="IsImmediateFavoriteSyncEnabled"/>
+                                <span>Enable immediate favorite sync</span>
+                            </label>
+                            <div class="fieldDescription">Sync favorite status immediately instead of after playback.</div>
+                        </div>
                         <div class="sectionTitleContainer flex align-items-center">
                             <h4 class="sectionTitle">Allowed libraries for listen submission</h4>
                             <div class="raised button-alt headerHelpButton emby-button" id="ResetAllowedLibraries">
@@ -365,6 +373,9 @@
             document.querySelector("#IsAlternativeModeEnabled")
                 .checked = data.IsAlternativeModeEnabled;
 
+            document.querySelector("#IsImmediateFavoriteSyncEnabled")
+                .checked = data.IsImmediateFavoriteSyncEnabled;
+
             try {
                 buildAllowedLibrariesList(data.LibraryConfigs);
             } catch (err) {
@@ -414,6 +425,7 @@
                 MusicBrainzApiUrl: document.querySelector('#MusicBrainzApiUrl').value,
                 IsMusicBrainzEnabled: document.querySelector('#IsMusicBrainzEnabled').checked,
                 IsAlternativeModeEnabled: document.querySelector('#IsAlternativeModeEnabled').checked,
+                IsImmediateFavoriteSyncEnabled: document.querySelector('#IsImmediateFavoriteSyncEnabled').checked,
                 LibraryConfigs: getLibraryConfigsInputs(),
             }
         }

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/configurationPage.html
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/configurationPage.html
@@ -117,9 +117,9 @@
                             <label class="inputLabel inputLabelUnfocused" for="IsImmediateFavoriteSyncEnabled">
                                 <input is="emby-checkbox" type="checkbox" id="IsImmediateFavoriteSyncEnabled"
                                        name="IsImmediateFavoriteSyncEnabled"/>
-                                <span>Enable immediate favorite sync</span>
+                                <span>Immediate favorite sync</span>
                             </label>
-                            <div class="fieldDescription">Sync favorite status immediately instead of after playback.</div>
+                            <div class="fieldDescription">Sync favorite status immediately. Requires MusicBrainz metadata and integration to be enabled.</div>
                         </div>
                         <div class="sectionTitleContainer flex align-items-center">
                             <h4 class="sectionTitle">Allowed libraries for listen submission</h4>

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -251,13 +251,20 @@ public class PluginImplementation
                 return;
             case UserDataSaveReason.PlaybackFinished:
                 _logger.LogDebug("Reason is playback finished, evaluating listen conditions");
-                // TODO: split
-                break;
+                HandlePlaybackFinished(data);
+                return;
             default:
                 _logger.LogDebug("Dropping event - unsupported data save reason");
                 return;
         }
+    }
 
+    /// <summary>
+    /// Handle playback finished event (alternative recognition of listens).
+    /// </summary>
+    /// <param name="data">Event data.</param>
+    private void HandlePlaybackFinished(EventData data)
+    {
         var config = Plugin.GetConfiguration();
         if (!config.IsAlternativeModeEnabled)
         {

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -361,6 +361,10 @@ public class PluginImplementation
         }
     }
 
+    /// <summary>
+    /// Handle favorite sync using MBID. Does not fall back to using MSID.
+    /// </summary>
+    /// <param name="data">Event data.</param>
     private void HandleFavoriteSyncUsingMbid(EventData data)
     {
         var config = Plugin.GetConfiguration();

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -367,15 +367,9 @@ public class PluginImplementation
     /// <param name="data">Event data.</param>
     private void HandleFavoriteSyncUsingMbid(EventData data)
     {
-        var config = Plugin.GetConfiguration();
-        if (!config.IsImmediateFavoriteSyncEnabled)
-        {
-            _logger.LogDebug("Immediate sync is disabled");
-            return;
-        }
-
         try
         {
+            AssertImmediateFavoriteSyncIsEnabled();
             _logger.LogDebug("Checking if favorite sync is enabled");
             var userConfig = data.JellyfinUser.GetListenBrainzConfig();
             if (!userConfig.IsFavoritesSyncEnabled)
@@ -421,6 +415,21 @@ public class PluginImplementation
         }
 
         _logger.LogDebug("MusicBrainz integration is enabled");
+    }
+
+    /// <summary>
+    /// Asser immediate favorite sync is enabled.
+    /// </summary>
+    /// <exception cref="PluginException">Immediate favorite sync is disabled.</exception>
+    private void AssertImmediateFavoriteSyncIsEnabled()
+    {
+        _logger.LogDebug("Checking if immediate favorite sync is enabled");
+        if (!Plugin.GetConfiguration().IsImmediateFavoriteSyncEnabled)
+        {
+            throw new PluginException("Immediate favorite sync is disabled");
+        }
+
+        _logger.LogDebug("Immediate favorite sync is enabled");
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -363,6 +363,13 @@ public class PluginImplementation
 
     private void HandleFavoriteSyncUsingMbid(EventData data)
     {
+        var config = Plugin.GetConfiguration();
+        if (!config.IsImmediateFavoriteSyncEnabled)
+        {
+            _logger.LogDebug("Immediate sync is not enabled");
+            return;
+        }
+
         try
         {
             _logger.LogDebug("Getting user configuration");

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -372,13 +372,15 @@ public class PluginImplementation
 
         try
         {
-            _logger.LogDebug("Getting user configuration");
+            _logger.LogDebug("Checking if favorite sync is enabled");
             var userConfig = data.JellyfinUser.GetListenBrainzConfig();
             if (!userConfig.IsFavoritesSyncEnabled)
             {
                 _logger.LogDebug("Favorite sync is disabled");
                 return;
             }
+
+            _logger.LogDebug("Favorite sync is enabled");
 
             _logger.LogInformation("Getting additional metadata...");
             var metadata = _metadataClient.GetAudioItemMetadata(data.Item);

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -370,6 +370,8 @@ public class PluginImplementation
         try
         {
             AssertImmediateFavoriteSyncIsEnabled();
+            AssertMusicBrainzIsEnabled();
+
             _logger.LogDebug("Checking if favorite sync is enabled");
             var userConfig = data.JellyfinUser.GetListenBrainzConfig();
             if (!userConfig.IsFavoritesSyncEnabled)

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -366,7 +366,7 @@ public class PluginImplementation
         var config = Plugin.GetConfiguration();
         if (!config.IsImmediateFavoriteSyncEnabled)
         {
-            _logger.LogDebug("Immediate sync is not enabled");
+            _logger.LogDebug("Immediate sync is disabled");
             return;
         }
 


### PR DESCRIPTION
Improve UX: and allow syncing favorites immediately after favoriting a track in JF instead of after playback.
- Only if (track) MBID is available
- Optional and can be turned off (default on)