### PR TITLE
Fix manual installation path in readme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
         with:
-          dotnet-version: "6.0"
+          dotnet-version: "8.0"
 
       - name: Build Jellyfin Plugin
         uses: oddstr13/jellyfin-plugin-repository-manager@eabb903cdac8a7f6d94df887c6910b5720ec48f9 # v1.0.11

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ the [jellyfin plugin template](https://github.com/jellyfin/jellyfin-plugin-templ
 
 ## Manual build and installation
 
-.NET 6.0 is required to build the plugin.
+.NET 8.0 is required to build the plugin.
 To install the .NET SDK, check out the [.NET download page](https://dotnet.microsoft.com/download).
 
 Once the SDK is installed, you should be able to compile the plugin in either debug or release configuration:
@@ -124,7 +124,7 @@ Once the SDK is installed, you should be able to compile the plugin in either de
 ```
 
 Once the build is completed, the compiled DLLs should be available at:
-`src/Jellyfin.Plugin.Listenbrainz/bin/<Debug|Release>/net6.0/`
+`src/Jellyfin.Plugin.Listenbrainz/bin/<Debug|Release>/net8.0/`
 
 To install the plugin for the first time, copy all **DLL** files starting with `Jellyfin.Plugin.ListenBrainz` to the
 plugin directory in your Jellyfin config directory (`${CONFIG_DIR}/plugins/Jellyfin.Plugin.ListenBrainz_1.0.0.0`).

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Once the build is completed, the compiled DLLs should be available at:
 `src/Jellyfin.Plugin.Listenbrainz/bin/<Debug|Release>/net8.0/`
 
 To install the plugin for the first time, copy all **DLL** files starting with `Jellyfin.Plugin.ListenBrainz` to the
-plugin directory in your Jellyfin config directory (`${CONFIG_DIR}/plugins/Jellyfin.Plugin.ListenBrainz_1.0.0.0`).
+plugin directory in your Jellyfin config directory (`${CONFIG_DIR}/plugins/ListenBrainz_1.0.0.0`).
 Create the plugin directory if it does not exist, and make sure Jellyfin has correct permissions to access it.
 
 Then copy all the DLL files and restart the Jellyfin server. After restarting Jellyfin, the plugin should be recognized

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "3.4.1.0"
-targetAbi: "10.8.0.0"
+version: "4.0.0.0"
+targetAbi: "10.9.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."
 description: >
@@ -17,4 +17,4 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
   Maintenance
-    - Revert back to custom MusicBrainz client to avoid dependency conflicts (#89 @lyarenei)
+    - Compatibility update for Jellyfin 10.9 (#xx @lyarenei)

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
 version: "3.4.1.0"
 targetAbi: "10.8.0.0"
-framework: "net6.0"
+framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."
 description: >
   A plugin to send your music listening activity on Jellyfin to ListenBrainz.

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "4.0.0.0"
+version: "4.0.0.1"
 targetAbi: "10.9.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."
@@ -17,4 +17,4 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
   Maintenance
-    - Compatibility update for Jellyfin 10.9 (#xx @lyarenei)
+    - Compatibility update for Jellyfin 10.9 (#93 @lyarenei)

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Jellyfin.Plugin.ListenBrainz.Api.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Jellyfin.Plugin.ListenBrainz.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Jellyfin.Plugin.ListenBrainz.Api.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Jellyfin.Plugin.ListenBrainz.Api.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
       <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />

--- a/src/Jellyfin.Plugin.ListenBrainz.Common/Jellyfin.Plugin.ListenBrainz.Common.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Common/Jellyfin.Plugin.ListenBrainz.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Jellyfin.Plugin.ListenBrainz.Common/Jellyfin.Plugin.ListenBrainz.Common.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Common/Jellyfin.Plugin.ListenBrainz.Common.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
       <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
       <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
       <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />

--- a/src/Jellyfin.Plugin.ListenBrainz.Http/Jellyfin.Plugin.ListenBrainz.Http.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Http/Jellyfin.Plugin.ListenBrainz.Http.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Jellyfin.Plugin.ListenBrainz.Http/Jellyfin.Plugin.ListenBrainz.Http.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Http/Jellyfin.Plugin.ListenBrainz.Http.csproj
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
         <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
         <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />

--- a/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
       <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
       <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
       <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />

--- a/src/Jellyfin.Plugin.ListenBrainz/Dtos/JellyfinMediaLibrary.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Dtos/JellyfinMediaLibrary.cs
@@ -24,7 +24,7 @@ public class JellyfinMediaLibrary
     {
         Name = item.Name;
         Id = item.Id;
-        LibraryType = item.CollectionType;
+        LibraryType = item.CollectionType.Value.ToString();
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.ListenBrainz/EntryPoint.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/EntryPoint.cs
@@ -1,7 +1,7 @@
 using Jellyfin.Plugin.ListenBrainz.Utils;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Controller.Session;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.ListenBrainz;
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.ListenBrainz;
 /// <summary>
 /// ListenBrainz plugin entrypoint for Jellyfin server.
 /// </summary>
-public sealed class EntryPoint : IServerEntryPoint
+public sealed class EntryPoint : IHostedService
 {
     private readonly ISessionManager _sessionManager;
     private readonly IUserDataManager _userDataManager;
@@ -51,7 +51,7 @@ public sealed class EntryPoint : IServerEntryPoint
     }
 
     /// <inheritdoc />
-    public Task RunAsync()
+    public Task StartAsync(CancellationToken cancellationToken)
     {
         _sessionManager.PlaybackStart += _plugin.OnPlaybackStart;
         _sessionManager.PlaybackStopped += _plugin.OnPlaybackStop;
@@ -60,10 +60,11 @@ public sealed class EntryPoint : IServerEntryPoint
     }
 
     /// <inheritdoc />
-    public void Dispose()
+    public Task StopAsync(CancellationToken cancellationToken)
     {
         _sessionManager.PlaybackStart -= _plugin.OnPlaybackStart;
         _sessionManager.PlaybackStopped -= _plugin.OnPlaybackStop;
         _userDataManager.UserDataSaved -= _plugin.OnUserDataSave;
+        return Task.CompletedTask;
     }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/LibraryManagerExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/LibraryManagerExtensions.cs
@@ -1,3 +1,4 @@
+using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 
@@ -30,6 +31,6 @@ public static class LibraryManagerExtensions
     {
         return GetLibraries(libraryManager)
             .Cast<CollectionFolder>()
-            .Where(f => f.CollectionType == "music");
+            .Where(f => f.CollectionType == CollectionType.music);
     }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
@@ -11,8 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Jellyfin.Controller" Version="10.8.0" />
-      <PackageReference Include="Jellyfin.Model" Version="10.8.0" />
+      <PackageReference Include="Jellyfin.Controller" Version="10.9.0-20240307.3" />
+      <PackageReference Include="Jellyfin.Data" Version="10.9.0-20240307.3" />
+      <PackageReference Include="Jellyfin.Model" Version="10.9.0-20240307.3" />
       <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
       <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
       <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginService.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginService.cs
@@ -7,16 +7,16 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.ListenBrainz;
 
 /// <summary>
-/// ListenBrainz plugin entrypoint for Jellyfin server.
+/// ListenBrainz plugin service for Jellyfin server.
 /// </summary>
-public sealed class EntryPoint : IHostedService
+public sealed class PluginService : IHostedService
 {
     private readonly ISessionManager _sessionManager;
     private readonly IUserDataManager _userDataManager;
     private readonly PluginImplementation _plugin;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="EntryPoint"/> class.
+    /// Initializes a new instance of the <see cref="PluginService"/> class.
     /// </summary>
     /// <param name="sessionManager">Session manager.</param>
     /// <param name="loggerFactory">Logger factory.</param>
@@ -24,7 +24,7 @@ public sealed class EntryPoint : IHostedService
     /// <param name="userDataManager">User data manager.</param>
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="userManager">User manager.</param>
-    public EntryPoint(
+    public PluginService(
         ISessionManager sessionManager,
         ILoggerFactory loggerFactory,
         IHttpClientFactory clientFactory,

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Data.Entities;
+using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.ListenBrainz.Configuration;
 using Jellyfin.Plugin.ListenBrainz.Extensions;
 using Jellyfin.Plugin.ListenBrainz.Interfaces;

--- a/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/Jellyfin.Plugin.ListenBrainz.Api.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/Jellyfin.Plugin.ListenBrainz.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/Jellyfin.Plugin.ListenBrainz.Api.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/Jellyfin.Plugin.ListenBrainz.Api.Tests.csproj
@@ -8,14 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/JsonEncodeTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/JsonEncodeTests.cs
@@ -54,15 +54,16 @@ public class RecordingFeedbackTests
         yield return new [] { Neutral };
     }
 
-    [Theory]
-    [MemberData(nameof(GetFeedbackScores))]
-    public void FeedbackValues_Encode(FeedbackScore score)
-    {
-        var request = new RecordingFeedbackRequest { Score = score };
-        var actualJson = JsonConvert.SerializeObject(request, BaseApiClient.SerializerSettings);
-        Assert.NotNull(actualJson);
-
-        var expectedJson = @"{""score"":" + score.Value + "}";
-        Assert.Equal(expectedJson, actualJson);
-    }
+    // TODO: fix xunit error 1019
+    // [Theory]
+    // [MemberData(nameof(GetFeedbackScores))]
+    // public void FeedbackValues_Encode(FeedbackScore score)
+    // {
+    //     var request = new RecordingFeedbackRequest { Score = score };
+    //     var actualJson = JsonConvert.SerializeObject(request, BaseApiClient.SerializerSettings);
+    //     Assert.NotNull(actualJson);
+    //
+    //     var expectedJson = @"{""score"":" + score.Value + "}";
+    //     Assert.Equal(expectedJson, actualJson);
+    // }
 }

--- a/tests/Jellyfin.Plugin.ListenBrainz.Http.Tests/Jellyfin.Plugin.ListenBrainz.Http.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Http.Tests/Jellyfin.Plugin.ListenBrainz.Http.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Http.Tests/Jellyfin.Plugin.ListenBrainz.Http.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Http.Tests/Jellyfin.Plugin.ListenBrainz.Http.Tests.csproj
@@ -8,14 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests.csproj
@@ -8,14 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
I tried manually installing [listenbrainz_4.0.0.1.zip](https://github.com/lyarenei/jellyfin-plugin-listenbrainz/files/15047856/listenbrainz_4.0.0.1.zip) from https://github.com/lyarenei/jellyfin-plugin-listenbrainz/pull/93#issuecomment-2067243185 in Jellyfin 10.9, but got this error:

```
[14:26:57] [ERR] Error creating Jellyfin.Plugin.ListenBrainz.Plugin
Jellyfin.Plugin.ListenBrainz.Exceptions.PluginException: Saving cache failed
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/config/plugins/ListenBrainz_1.0.0.0/cache.json'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.Create(String path)
   at Jellyfin.Plugin.ListenBrainz.Managers.ListensCacheManager.Save()
   --- End of inner exception stack trace ---
   at Jellyfin.Plugin.ListenBrainz.Managers.ListensCacheManager.Save()
   at Jellyfin.Plugin.ListenBrainz.Managers.ListensCacheManager.get_Instance()
   at Jellyfin.Plugin.ListenBrainz.PluginImplementation..ctor(ILogger logger, IListenBrainzClient listenBrainzClient, IMusicBrainzClient musicBrainzClient, IUserDataManager userDataManager, IUserManager userManager, ILibraryManager libraryManager)
   at Jellyfin.Plugin.ListenBrainz.PluginService..ctor(ISessionManager sessionManager, ILoggerFactory loggerFactory, IHttpClientFactory clientFactory, IUserDataManager userDataManager, ILibraryManager libraryManager, IUserManager userManager)
   at Jellyfin.Plugin.ListenBrainz.Plugin..ctor(IApplicationPaths paths, IXmlSerializer xmlSerializer, ISessionManager sessionManager, ILoggerFactory loggerFactory, IHttpClientFactory clientFactory, IUserDataManager userDataManager, ILibraryManager libraryManager, IUserManager userManager)
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithManyArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.ConstructorMatcher.CreateInstance(IServiceProvider provider)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
   at Emby.Server.Implementations.Plugins.PluginManager.CreatePluginInstance(Type type)
```

Changing the installation path from `plugins/Jellyfin.Plugin.ListenBrainz_1.0.0.0` to `plugins/ListenBrainz_1.0.0.0` fixed it, so updating the readme to reflect that.

This PR is against the `jellyfin-10.9.x` branch because that's what I tested, but it looks like it also applies to `main`.