### PR TITLE
Fix manual installation path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Once the build is completed, the compiled DLLs should be available at:
 `src/Jellyfin.Plugin.Listenbrainz/bin/<Debug|Release>/net6.0/`
 
 To install the plugin for the first time, copy all **DLL** files starting with `Jellyfin.Plugin.ListenBrainz` to the
-plugin directory in your Jellyfin config directory (`${CONFIG_DIR}/plugins/Jellyfin.Plugin.ListenBrainz_1.0.0.0`).
+plugin directory in your Jellyfin config directory (`${CONFIG_DIR}/plugins/ListenBrainz_1.0.0.0`).
 Create the plugin directory if it does not exist, and make sure Jellyfin has correct permissions to access it.
 
 Then copy all the DLL files and restart the Jellyfin server. After restarting Jellyfin, the plugin should be recognized


### PR DESCRIPTION
(Same as github.com/lyarenei/jellyfin-plugin-listenbrainz/pull/94, but against `main` branch.)

I tried manually installing [listenbrainz_4.0.0.1.zip](https://github.com/lyarenei/jellyfin-plugin-listenbrainz/files/15047856/listenbrainz_4.0.0.1.zip) from https://github.com/lyarenei/jellyfin-plugin-listenbrainz/pull/93#issuecomment-2067243185 in Jellyfin 10.9, but got this error:

```
[14:26:57] [ERR] Error creating Jellyfin.Plugin.ListenBrainz.Plugin
Jellyfin.Plugin.ListenBrainz.Exceptions.PluginException: Saving cache failed
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/config/plugins/ListenBrainz_1.0.0.0/cache.json'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.Create(String path)
   at Jellyfin.Plugin.ListenBrainz.Managers.ListensCacheManager.Save()
   --- End of inner exception stack trace ---
   at Jellyfin.Plugin.ListenBrainz.Managers.ListensCacheManager.Save()
   at Jellyfin.Plugin.ListenBrainz.Managers.ListensCacheManager.get_Instance()
   at Jellyfin.Plugin.ListenBrainz.PluginImplementation..ctor(ILogger logger, IListenBrainzClient listenBrainzClient, IMusicBrainzClient musicBrainzClient, IUserDataManager userDataManager, IUserManager userManager, ILibraryManager libraryManager)
   at Jellyfin.Plugin.ListenBrainz.PluginService..ctor(ISessionManager sessionManager, ILoggerFactory loggerFactory, IHttpClientFactory clientFactory, IUserDataManager userDataManager, ILibraryManager libraryManager, IUserManager userManager)
   at Jellyfin.Plugin.ListenBrainz.Plugin..ctor(IApplicationPaths paths, IXmlSerializer xmlSerializer, ISessionManager sessionManager, ILoggerFactory loggerFactory, IHttpClientFactory clientFactory, IUserDataManager userDataManager, ILibraryManager libraryManager, IUserManager userManager)
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithManyArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.ConstructorMatcher.CreateInstance(IServiceProvider provider)
   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
   at Emby.Server.Implementations.Plugins.PluginManager.CreatePluginInstance(Type type)
```

Changing the installation path from `plugins/Jellyfin.Plugin.ListenBrainz_1.0.0.0` to `plugins/ListenBrainz_1.0.0.0` fixed it, so updating the readme to reflect that.