### PR TITLE
Handle metadata exception when fetch fails during loved sync (LB -> JF)

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -73,6 +73,7 @@ public class LovedTracksSyncTask : IScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
+        using var logScope = BeginLogScope();
         Reset();
         var conf = Plugin.GetConfiguration();
         if (!conf.IsMusicBrainzEnabled)
@@ -213,5 +214,10 @@ public class LovedTracksSyncTask : IScheduledTask
     {
         _userCountRatio = 100.0 / Plugin.GetConfiguration().UserConfigs.Count;
         _progress = 0;
+    }
+
+    private IDisposable? BeginLogScope()
+    {
+        return _logger.BeginScope(new Dictionary<string, object> { { "EventId", "LovedTracksSyncTask" } });
     }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -154,6 +154,7 @@ public class LovedTracksSyncTask : IScheduledTask
             catch (OperationCanceledException)
             {
                 _logger.LogInformation("Task has been cancelled");
+                throw;
             }
             catch (Exception e)
             {

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -147,7 +147,12 @@ public class LovedTracksSyncTask : IScheduledTask
             var recordingMbid = string.Empty;
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 recordingMbid = _musicBrainzClient.GetAudioItemMetadata(item).RecordingMbid;
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("Task has been cancelled");
             }
             catch (Exception e)
             {

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -142,12 +142,21 @@ public class LovedTracksSyncTask : IScheduledTask
             .Where(i => i.ProviderIds.GetValueOrDefault("MusicBrainzTrack") is not null)
             .ToList();
 
-        var itemMbidPairs = items.Select(i => (Item: i, _musicBrainzClient.GetAudioItemMetadata(i).RecordingMbid));
-        foreach (var item in itemMbidPairs)
+        foreach (var item in items)
         {
-            if (lovedTracksIds.Contains(item.RecordingMbid))
+            var recordingMbid = string.Empty;
+            try
             {
-                MarkAsFavorite(user, item.Item, cancellationToken);
+                recordingMbid = _musicBrainzClient.GetAudioItemMetadata(item).RecordingMbid;
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning("Failed to get metadata for item {ItemId}: {Error}", item.Id, e.Message);
+            }
+
+            if (lovedTracksIds.Contains(recordingMbid))
+            {
+                MarkAsFavorite(user, item, cancellationToken);
             }
 
             _progress += _userCountRatio / items.Count;


### PR DESCRIPTION
- Handle exception when metadata are not available (#96)
- Handle task cancellation during processing
- Add logging scope

Should fix #96.