### PR TITLE
Fixes submission with multiple artists. Parses commas and Trims

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
@@ -53,7 +53,7 @@ public static class AudioExtensions
                     SubmissionClient = Plugin.FullName,
                     SubmissionClientVersion = Plugin.Version,
                     ReleaseMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzAlbum"),
-                    ArtistMbids = item.ProviderIds.GetValueOrDefault("MusicBrainzArtist")?.Split(';', '/'),
+                    ArtistMbids = item.ProviderIds.GetValueOrDefault("MusicBrainzArtist")?.Split(';', '/', ',').Select(s => s.Trim()).ToArray(),
                     ReleaseGroupMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzReleaseGroup"),
                     RecordingMbid = itemMetadata?.RecordingMbid,
                     TrackMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzTrack"),


### PR DESCRIPTION
Fixes an issue with multiple MBIDs. I use APE files with APEv2 tags. Maybe this fixes other formats/tags.

Original request without this fix returns "BadRequest" due to `artist_mbids` not being splitted/parsed properly.

```
[2024-09-21 14:04:49.618 +00:00] [DBG] [20] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Response status is BadRequest, will not retry
[2024-09-21 14:04:49.619 +00:00] [DBG] [20] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Got response:
Data: "{\"code\":400,\"error\":\"artist_mbids MBID format invalid.\",\"track_metadata\":{\"additional_info\":{\"artist_mbids\":[\"17f0182e-146a-4115-8c83-aa291b4e3acc, bb53bece-e3ed-4a9e-9348-265745dcb239\"],\"duration_ms\":205000,\"isrc\":\"USAT29700167\",\"media_player\":\"Jellyfin\",\"recording_mbid\":\"c5a61a3a-46e4-4c7b-b511-b9a67912b86d\",\"release_group_mbid\":\"2c5b5cf7-d6fc-32e9-b68f-8e8fb8747aaa\",\"release_mbid\":\"9a7768c5-7a5a-4a80-9f3e-0a86ec174c8c\",\"submission_client\":\"ListenBrainz plugin for Jellyfin\",\"submission_client_version\":\"1.0.0.0\",\"tags\":[],\"track_mbid\":\"8f4f0b0e-3729-398a-a2bd-1ad76021a07c\",\"tracknumber\":1},\"artist_name\":\"Jonathan Dokuchitz, Kelsey Grammer and Townspeople\",\"release_name\":\"Anastasia\",\"track_name\":\"A Rumor in St. Petersburg\"}}
[2024-09-21 14:04:49.619 +00:00] [DBG] [20] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Did not hit any rate limits, all OK
[2024-09-21 14:04:49.619 +00:00] [DBG] [20] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Request has been processed, freeing up resources
[2024-09-21 14:04:49.619 +00:00] [INF] [23] Jellyfin.Plugin.ListenBrainz: Failed to send 'playing now' listen: "Sending now playing failed"
```

After splitting the comma, it also failed due to a whitespace:

```
[2024-09-21 14:17:44.825 +00:00] [DBG] [16] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Response status is BadRequest, will not retry
[2024-09-21 14:17:44.825 +00:00] [DBG] [16] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Got response:
Data: "{\"code\":400,\"error\":\"artist_mbids MBID format invalid.\",\"track_metadata\":{\"additional_info\":{\"artist_mbids\":[\"17f0182e-146a-4115-8c83-aa291b4e3acc\",\" bb53bece-e3ed-4a9e-9348-265745dcb239\"],\"duration_ms\":168000,\"isrc\":\"USAT29700169\",\"media_player\":\"Jellyfin\",\"recording_mbid\":\"e8330f3b-aff9-48f1-912e-156de9e12ca7\",\"release_group_mbid\":\"2c5b5cf7-d6fc-32e9-b68f-8e8fb8747aaa\",\"release_mbid\":\"9a7768c5-7a5a-4a80-9f3e-0a86ec174c8c\",\"submission_client\":\"ListenBrainz plugin for Jellyfin\",\"submission_client_version\":\"1.0.0.0\",\"tags\":[],\"track_mbid\":\"7208f8b5-3541-3a39-b220-67e9757aac11\",\"tracknumber\":3},\"artist_name\":\"Liz Callaway\",\"release_name\":\"Anastasia\",\"track_name\":\"Once Upon a December\"}}
[2024-09-21 14:17:44.827 +00:00] [DBG] [16] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Did not hit any rate limits, all OK
[2024-09-21 14:17:44.828 +00:00] [DBG] [16] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Request has been processed, freeing up resources
[2024-09-21 14:17:44.849 +00:00] [INF] [21] Jellyfin.Plugin.ListenBrainz: Failed to send 'playing now' listen: "Sending now playing failed"
[2024-09-21 14:17:44.849 +00:00] [DBG] [21] Jellyfin.Plugin.ListenBrainz: Failed to send 'playing now' listen

```

So I added a Trim to it. Now it works:

```
[2024-09-21 14:31:18.480 +00:00] [DBG] [25] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Sending request:
Data: "{\"listen_type\":\"playing_now\",\"payload\":[{\"track_metadata\":{\"artist_name\":\"Kelsey Grammer, Liz Callaway and Jonathan Dokuchitz\",\"track_name\":\"Learn to Do It\",\"release_name\":\"Anastasia\",\"additional_info\":{\"artist_mbids\":[\"17f0182e-146a-4115-8c83-aa291b4e3acc\",\"bb53bece-e3ed-4a9e-9348-265745dcb239\"],\"release_group_mbid\":\"2c5b5cf7-d6fc-32e9-b68f-8e8fb8747aaa\",\"release_mbid\":\"9a7768c5-7a5a-4a80-9f3e-0a86ec174c8c\",\"recording_mbid\":\"59542aed-9689-4e29-8ee8-70db2c18b2b9\",\"track_mbid\":\"a5762a61-6b06-3a94-9f1a-c7180747df10\",\"tracknumber\":5,\"isrc\":\"USAT29700182\",\"tags\":[],\"media_player\":\"Jellyfin\",\"submission_client\":\"ListenBrainz plugin for Jellyfin\",\"submission_client_version\":\"1.0.0.0\",\"duration_ms\":156000}}}]}"
[2024-09-21 14:31:18.482 +00:00] [INF] [23] Jellyfin.Plugin.ListenBrainz: Attempting to sync favorite status for track "In the Dark of the Night" and user "moisespr123"
[2024-09-21 14:31:18.482 +00:00] [INF] [23] Jellyfin.Plugin.ListenBrainz: Recording MBID is available, using it for favorite sync
[2024-09-21 14:31:18.487 +00:00] [DBG] [23] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Waiting for previous request to complete (if any)
[2024-09-21 14:31:18.642 +00:00] [DBG] [25] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Response status is OK, will not retry
[2024-09-21 14:31:18.642 +00:00] [DBG] [25] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Got response:
[2024-09-21 14:31:18.642 +00:00] [DBG] [25] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Did not hit any rate limits, all OK
[2024-09-21 14:31:18.642 +00:00] [DBG] [25] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Request has been processed, freeing up resources
[2024-09-21 14:31:18.642 +00:00] [INF] [21] Jellyfin.Plugin.ListenBrainz: Successfully sent 'playing now' listen
```

A bit more information:

* The tracks were tagged with MusicBrainz Picard
* See submissions of the album Anastasia: https://listenbrainz.org/user/moisespr123/

The first tracks failed due to them having multiple artists. They are now hitting and being submitted properly.