### PR TITLE
Add parsing char 0x1F in artist_mbids

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
@@ -53,7 +53,7 @@ public static class AudioExtensions
                     SubmissionClient = Plugin.FullName,
                     SubmissionClientVersion = Plugin.Version,
                     ReleaseMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzAlbum"),
-                    ArtistMbids = item.ProviderIds.GetValueOrDefault("MusicBrainzArtist")?.Split(';', '/', ',').Select(s => s.Trim()).ToArray(),
+                    ArtistMbids = item.ProviderIds.GetValueOrDefault("MusicBrainzArtist")?.Split(';', '/', ',', (char)0x1F).Select(s => s.Trim()).ToArray(),
                     ReleaseGroupMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzReleaseGroup"),
                     RecordingMbid = itemMetadata?.RecordingMbid,
                     TrackMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzTrack"),


### PR DESCRIPTION
Seems some strings are formed with unicode characters and fails to submit:

Example, where it failed due to \u001f:

```
[2024-11-11 08:41:26.020 -05:00] [DBG] [20] Jellyfin.Plugin.ListenBrainz.ListenBrainzApi: Got response:
Status: BadRequest
Data: "{\"code\":400,\"error\":\"artist_mbids MBID format invalid.\",\"track_metadata\":{\"additional_info\":{\"artist_mbids\":[\"06d98c74-1861-4717-86b2-00c0a8b863ce\u001f4dc77d86-5ecf-460b-b01d-41e8f1272b6e\"],\"duration_ms\":358000,\"media_player\":\"Jellyfin\",\"recording_mbid\":\"e9c4280a-3665-45b9-80b9-0dada4e68bd3\",\"release_group_mbid\":\"7bfc2d50-d3f2-332e-9956-d706e5a69949\",\"release_mbid\":\"3e380934-aa90-4887-93df-8d8bb7487fe0\",\"submission_client\":\"ListenBrainz plugin for Jellyfin\",\"submission_client_version\":\"5.0.0.2\",\"tags\":[],\"track_mbid\":\"39732df6-5a80-3b36-93b0-1869451e3dd7\",\"tracknumber\":3},\"artist_name\":\"System S.F. feat. Anna\",\"release_name\":\"V-RARE SOUNDTRACK 5 - DDRMAX2 -Dance Dance Revolution 7thMIX-\",\"track_name\":\"Look To The Sky (Trance Extended Mix)\"}}
"
```

This PR now fixes it.

I'm not really sure why these issues happen, but glad to submit this quick PR fix to solve them.