### PR TITLE
Improve cached listen resubmission

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,5 +16,5 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.Http.dll"
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
-  New
-    - Listen backup feature (#102 @lyarenei)
+  Maintenance
+    - Improve error handling in resubmit listen process (#117 @lyarenei)

--- a/build.yaml
+++ b/build.yaml
@@ -17,4 +17,4 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
   Maintenance
-    - Improve error handling in resubmit listen process (#117 @lyarenei)
+    - Improve invalid listen handling in resubmit listen process (#117 @lyarenei)

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "5.1.1.0"
+version: "5.1.1.1"
 targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "5.0.2.0"
+version: "5.1.1.0"
 targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "5.1.1.1"
+version: "5.1.1.2"
 targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "5.1.1.2"
+version: "5.1.1.3"
 targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "8.0.0",
+        "rollForward": "latestMajor",
+        "allowPrerelease": false
+    }
+}

--- a/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
@@ -235,24 +235,6 @@ public class ListenBrainzClient : IListenBrainzClient
     }
 
     /// <summary>
-    /// Convert all <see cref="StoredListen"/>s to <see cref="Listen"/>s.
-    /// </summary>
-    /// <param name="storedListens">Stored listens to convert.</param>
-    /// <returns>Converted listens.</returns>
-    private IEnumerable<Listen> ToListens(IEnumerable<StoredListen> storedListens)
-    {
-        if (_libraryManager is null) throw new InvalidOperationException("Library manager is not available");
-
-        var listensToConvert = storedListens.ToArray();
-        return listensToConvert.Select(l =>
-        {
-            var baseItem = _libraryManager.GetItemById(l.Id);
-            var audio = (Audio?)baseItem ?? throw new PluginException("Invalid item");
-            return audio.AsListen(l.ListenedAt, l.Metadata);
-        });
-    }
-
-    /// <summary>
     /// Fetch ListenBrainz username using the API token.
     /// </summary>
     /// <param name="userApiToken">ListenBrainz API token.</param>

--- a/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
@@ -98,7 +98,11 @@ public class ListenBrainzClient : IListenBrainzClient
     }
 
     /// <inheritdoc />
-    public void SendFeedback(UserConfig config, bool isFavorite, string? recordingMbid = null, string? recordingMsid = null)
+    public void SendFeedback(
+        UserConfig config,
+        bool isFavorite,
+        string? recordingMbid = null,
+        string? recordingMsid = null)
     {
         var pluginConfig = Plugin.GetConfiguration();
         var request = new RecordingFeedbackRequest
@@ -125,7 +129,10 @@ public class ListenBrainzClient : IListenBrainzClient
 
     /// <inheritdoc />
     /// <exception cref="PluginException">Sending listens failed.</exception>
-    public async Task SendListensAsync(UserConfig config, IEnumerable<StoredListen> storedListens, CancellationToken cancellationToken)
+    public async Task SendListensAsync(
+        UserConfig config,
+        IEnumerable<StoredListen> storedListens,
+        CancellationToken cancellationToken)
     {
         var pluginConfig = Plugin.GetConfiguration();
         var request = new SubmitListensRequest
@@ -197,7 +204,11 @@ public class ListenBrainzClient : IListenBrainzClient
         GetUserFeedbackResponse response;
         do
         {
-            var request = new GetUserFeedbackRequest(config.UserName, FeedbackScore.Loved, Limits.MaxItemsPerGet, offset);
+            var request = new GetUserFeedbackRequest(
+                config.UserName,
+                FeedbackScore.Loved,
+                Limits.MaxItemsPerGet,
+                offset);
             try
             {
                 response = await _apiClient.GetUserFeedback(request, cancellationToken);

--- a/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Clients/ListenBrainzClient.cs
@@ -131,7 +131,7 @@ public class ListenBrainzClient : IListenBrainzClient
     /// <exception cref="PluginException">Sending listens failed.</exception>
     public async Task SendListensAsync(
         UserConfig config,
-        IEnumerable<StoredListen> storedListens,
+        IEnumerable<Listen> listens,
         CancellationToken cancellationToken)
     {
         var pluginConfig = Plugin.GetConfiguration();
@@ -139,7 +139,7 @@ public class ListenBrainzClient : IListenBrainzClient
         {
             ApiToken = config.PlaintextApiToken,
             ListenType = ListenType.Import,
-            Payload = ToListens(storedListens),
+            Payload = listens,
             BaseUrl = pluginConfig.ListenBrainzApiUrl
         };
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Dtos/StoredListen.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Dtos/StoredListen.cs
@@ -27,5 +27,5 @@ public class StoredListen
     /// Gets a value indicating whether this listen has MusicBrainz recording ID.
     /// </summary>
     [JsonIgnore]
-    public bool HasRecordingMbid => string.IsNullOrEmpty(Metadata?.RecordingMbid);
+    public bool HasRecordingMbid => !string.IsNullOrEmpty(Metadata?.RecordingMbid);
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Dtos/StoredListen.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Dtos/StoredListen.cs
@@ -1,4 +1,5 @@
 using MediaBrowser.Controller.Entities.Audio;
+using Newtonsoft.Json;
 
 namespace Jellyfin.Plugin.ListenBrainz.Dtos;
 
@@ -21,4 +22,10 @@ public class StoredListen
     /// Gets or sets additional metadata for <see cref="Audio"/> item.
     /// </summary>
     public AudioItemMetadata? Metadata { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this listen has MusicBrainz recording ID.
+    /// </summary>
+    [JsonIgnore]
+    public bool HasRecordingMbid => string.IsNullOrEmpty(Metadata?.RecordingMbid);
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/LibraryManagerExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/LibraryManagerExtensions.cs
@@ -1,5 +1,8 @@
 using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.ListenBrainz.Api.Models;
+using Jellyfin.Plugin.ListenBrainz.Dtos;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
 
 namespace Jellyfin.Plugin.ListenBrainz.Extensions;
@@ -32,5 +35,25 @@ public static class LibraryManagerExtensions
         return GetLibraries(libraryManager)
             .Cast<CollectionFolder>()
             .Where(f => f.CollectionType == CollectionType.music);
+    }
+
+    /// <summary>
+    /// Convert StoredListen to Listen.
+    /// </summary>
+    /// <param name="libraryManager">Library manager instance.</param>
+    /// <param name="listen">Stored listen to convert.</param>
+    /// <returns>Listen corresponding to provided stored listen. Null if conversion failed.</returns>
+    public static Listen? ToListen(this ILibraryManager libraryManager, StoredListen listen)
+    {
+        var baseItem = libraryManager.GetItemById(listen.Id);
+        try
+        {
+            var audio = (Audio?)baseItem;
+            return audio?.AsListen(listen.ListenedAt, listen.Metadata);
+        }
+        catch (InvalidCastException)
+        {
+            return null;
+        }
     }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListenBrainzClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListenBrainzClient.cs
@@ -1,3 +1,4 @@
+using Jellyfin.Plugin.ListenBrainz.Api.Models;
 using Jellyfin.Plugin.ListenBrainz.Configuration;
 using Jellyfin.Plugin.ListenBrainz.Dtos;
 using MediaBrowser.Controller.Entities.Audio;
@@ -42,10 +43,10 @@ public interface IListenBrainzClient
     /// Send multiple listens ('import') to ListenBrainz.
     /// </summary>
     /// <param name="config">ListenBrainz user configuration.</param>
-    /// <param name="storedListens">Listens to send.</param>
+    /// <param name="listens">Listens to send.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Task representing asynchronous operation.</returns>
-    public Task SendListensAsync(UserConfig config, IEnumerable<StoredListen> storedListens, CancellationToken cancellationToken);
+    public Task SendListensAsync(UserConfig config, IEnumerable<Listen> listens, CancellationToken cancellationToken);
 
     /// <summary>
     /// Validate specified API token.

--- a/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListensCache.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListensCache.cs
@@ -35,6 +35,13 @@ public interface IListensCache
     public IEnumerable<StoredListen> GetListens(Guid userId);
 
     /// <summary>
+    /// Remove specified listen from cache for specified user.
+    /// </summary>
+    /// <param name="userId">Jellyfin user ID associated with the listen.</param>
+    /// <param name="listen">Listen to remove.</param>
+    public void RemoveListen(Guid userId, StoredListen listen);
+
+    /// <summary>
     /// Remove specified listens from cache for specified user.
     /// </summary>
     /// <param name="userId">Jellyfin user ID associated with the listens.</param>

--- a/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListensCacheManager.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListensCacheManager.cs
@@ -1,0 +1,8 @@
+namespace Jellyfin.Plugin.ListenBrainz.Interfaces;
+
+/// <summary>
+/// Listen cache manager interface.
+/// </summary>
+public interface IListensCacheManager : ICacheManager, IListensCache, IDisposable
+{
+}

--- a/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
@@ -34,4 +34,8 @@
         <EmbeddedResource Include="Configuration\bootstrap-grid.min.css" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="Jellyfin.Plugin.ListenBrainz.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/src/Jellyfin.Plugin.ListenBrainz/Managers/ListensCacheManager.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Managers/ListensCacheManager.cs
@@ -241,6 +241,23 @@ public sealed class ListensCacheManager : ICacheManager, IListensCache, IDisposa
     }
 
     /// <inheritdoc />
+    public void RemoveListen(Guid userId, StoredListen listen)
+    {
+        _lock.Wait();
+        try
+        {
+            if (_listensCache.TryGetValue(userId, out var userListens))
+            {
+                userListens.Remove(listen);
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <inheritdoc />
     public void RemoveListens(Guid userId, IEnumerable<StoredListen> listens)
     {
         _lock.Wait();

--- a/src/Jellyfin.Plugin.ListenBrainz/Managers/ListensCacheManager.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Managers/ListensCacheManager.cs
@@ -10,7 +10,7 @@ namespace Jellyfin.Plugin.ListenBrainz.Managers;
 /// <summary>
 /// Cache manager.
 /// </summary>
-public sealed class ListensCacheManager : ICacheManager, IListensCache, IDisposable
+public sealed class ListensCacheManager : IListensCacheManager
 {
     /// <summary>
     /// Cache file name.

--- a/src/Jellyfin.Plugin.ListenBrainz/Managers/ListensCacheManager.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Managers/ListensCacheManager.cs
@@ -197,10 +197,7 @@ public sealed class ListensCacheManager : ICacheManager, IListensCache, IDisposa
         }
         catch (KeyNotFoundException)
         {
-            _listensCache[userId] = new List<StoredListen>
-            {
-                item.AsStoredListen(listenedAt, metadata)
-            };
+            _listensCache[userId] = new List<StoredListen> { item.AsStoredListen(listenedAt, metadata) };
         }
         finally
         {
@@ -218,10 +215,7 @@ public sealed class ListensCacheManager : ICacheManager, IListensCache, IDisposa
         }
         catch (KeyNotFoundException)
         {
-            _listensCache[userId] = new List<StoredListen>
-            {
-                item.AsStoredListen(listenedAt, metadata)
-            };
+            _listensCache[userId] = new List<StoredListen> { item.AsStoredListen(listenedAt, metadata) };
         }
         finally
         {

--- a/src/Jellyfin.Plugin.ListenBrainz/Plugin.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Plugin.cs
@@ -8,6 +8,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.ListenBrainz;
@@ -18,7 +19,7 @@ namespace Jellyfin.Plugin.ListenBrainz;
 public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     private static Plugin? _thisInstance;
-    private readonly PluginService _service;
+    private readonly IHostedService _service;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -31,6 +32,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="userDataManager">User data manager.</param>
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="userManager">User manager.</param>
+    /// <param name="pluginService">Plugin service.</param>
     public Plugin(
         IApplicationPaths paths,
         IXmlSerializer xmlSerializer,
@@ -39,16 +41,18 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         IHttpClientFactory clientFactory,
         IUserDataManager userDataManager,
         ILibraryManager libraryManager,
-        IUserManager userManager) : base(paths, xmlSerializer)
+        IUserManager userManager,
+        IHostedService? pluginService = null) : base(paths, xmlSerializer)
     {
         _thisInstance = this;
-        _service = new PluginService(
-            sessionManager,
-            loggerFactory,
-            clientFactory,
-            userDataManager,
-            libraryManager,
-            userManager);
+        _service = pluginService ??
+                   new PluginService(
+                       sessionManager,
+                       loggerFactory,
+                       clientFactory,
+                       userDataManager,
+                       libraryManager,
+                       userManager);
         _service.StartAsync(CancellationToken.None);
     }
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.Plugin.ListenBrainz.Tasks;
 public class ResubmitListensTask : IScheduledTask
 {
     private readonly ILogger _logger;
-    private readonly ListensCacheManager _listensCache;
+    private readonly IListensCacheManager _listensCache;
     private readonly IListenBrainzClient _listenBrainzClient;
     private readonly IMusicBrainzClient _musicBrainzClient;
     private readonly IUserManager _userManager;
@@ -34,18 +34,24 @@ public class ResubmitListensTask : IScheduledTask
     /// <param name="clientFactory">HTTP client factory.</param>
     /// <param name="userManager">User manager.</param>
     /// <param name="libraryManager">Library manager.</param>
+    /// <param name="listensCacheManager">Listens cache instance.</param>
+    /// <param name="listenBrainzClient">ListenBrainz client.</param>
+    /// <param name="musicBrainzClient">MusicBRainz client.</param>
     public ResubmitListensTask(
         ILoggerFactory loggerFactory,
         IHttpClientFactory clientFactory,
         IUserManager userManager,
-        ILibraryManager libraryManager)
+        ILibraryManager libraryManager,
+        IListensCacheManager? listensCacheManager = null,
+        IListenBrainzClient? listenBrainzClient = null,
+        IMusicBrainzClient? musicBrainzClient = null)
     {
         _logger = loggerFactory.CreateLogger($"{Plugin.LoggerCategory}.ResubmitListensTask");
-        _listensCache = ListensCacheManager.Instance;
-        _listenBrainzClient = ClientUtils.GetListenBrainzClient(_logger, clientFactory, libraryManager);
-        _musicBrainzClient = ClientUtils.GetMusicBrainzClient(_logger, clientFactory);
         _userManager = userManager;
         _libraryManager = libraryManager;
+        _listensCache = listensCacheManager ?? ListensCacheManager.Instance;
+        _listenBrainzClient = listenBrainzClient ?? ClientUtils.GetListenBrainzClient(_logger, clientFactory, libraryManager);
+        _musicBrainzClient = musicBrainzClient ?? ClientUtils.GetMusicBrainzClient(_logger, clientFactory);
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -34,7 +34,11 @@ public class ResubmitListensTask : IScheduledTask
     /// <param name="clientFactory">HTTP client factory.</param>
     /// <param name="userManager">User manager.</param>
     /// <param name="libraryManager">Library manager.</param>
-    public ResubmitListensTask(ILoggerFactory loggerFactory, IHttpClientFactory clientFactory, IUserManager userManager, ILibraryManager libraryManager)
+    public ResubmitListensTask(
+        ILoggerFactory loggerFactory,
+        IHttpClientFactory clientFactory,
+        IUserManager userManager,
+        ILibraryManager libraryManager)
     {
         _logger = loggerFactory.CreateLogger($"{Plugin.LoggerCategory}.ResubmitListensTask");
         _listensCache = ListensCacheManager.Instance;
@@ -113,7 +117,10 @@ public class ResubmitListensTask : IScheduledTask
         return TimeSpan.TicksPerDay + (randomMinute * TimeSpan.TicksPerMinute);
     }
 
-    private async Task SubmitListensForUser(PluginConfiguration pluginConfig, Guid userId, CancellationToken cancellationToken)
+    private async Task SubmitListensForUser(
+        PluginConfiguration pluginConfig,
+        Guid userId,
+        CancellationToken cancellationToken)
     {
         var user = _userManager.GetUserById(userId);
         if (user is null)

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -115,7 +115,7 @@ public class ResubmitListensTask : IScheduledTask
         };
     }
 
-    private static long GetInterval()
+    internal static long GetInterval()
     {
         var random = new Random();
         var randomMinute = random.Next(50);

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -129,7 +129,7 @@ public class ResubmitListensTask : IScheduledTask
         {
             var validListens = listenChunk
                 .TakeWhile(IsValidListen)
-                .Select(l => pluginConfig.IsMusicBrainzEnabled ? UpdateMetadataIfNecessary(l) : l)
+                .Select(l => pluginConfig.IsMusicBrainzEnabled ? UpdateMetadataIfNecessary(l, ct) : l)
                 .WhereNotNull()
                 .ToArray();
 
@@ -185,7 +185,7 @@ public class ResubmitListensTask : IScheduledTask
         }
     }
 
-    internal StoredListen? UpdateMetadataIfNecessary(StoredListen listen)
+    internal StoredListen? UpdateMetadataIfNecessary(StoredListen listen, CancellationToken ct)
     {
         if (_libraryManager.GetItemById(listen.Id) is not Audio item)
         {
@@ -198,6 +198,7 @@ public class ResubmitListensTask : IScheduledTask
             return listen;
         }
 
+        ct.ThrowIfCancellationRequested();
         try
         {
             listen.Metadata = _musicBrainzClient.GetAudioItemMetadata(item);

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -22,7 +22,6 @@ public class ResubmitListensTask : IScheduledTask
     private readonly IListensCacheManager _listensCache;
     private readonly IListenBrainzClient _listenBrainzClient;
     private readonly IMusicBrainzClient _musicBrainzClient;
-    private readonly IUserManager _userManager;
     private readonly ILibraryManager _libraryManager;
 
     /// <summary>
@@ -30,7 +29,6 @@ public class ResubmitListensTask : IScheduledTask
     /// </summary>
     /// <param name="loggerFactory">Logger factory.</param>
     /// <param name="clientFactory">HTTP client factory.</param>
-    /// <param name="userManager">User manager.</param>
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="listensCacheManager">Listens cache instance.</param>
     /// <param name="listenBrainzClient">ListenBrainz client.</param>
@@ -38,14 +36,12 @@ public class ResubmitListensTask : IScheduledTask
     public ResubmitListensTask(
         ILoggerFactory loggerFactory,
         IHttpClientFactory clientFactory,
-        IUserManager userManager,
         ILibraryManager libraryManager,
         IListensCacheManager? listensCacheManager = null,
         IListenBrainzClient? listenBrainzClient = null,
         IMusicBrainzClient? musicBrainzClient = null)
     {
         _logger = loggerFactory.CreateLogger($"{Plugin.LoggerCategory}.ResubmitListensTask");
-        _userManager = userManager;
         _libraryManager = libraryManager;
         _listensCache = listensCacheManager ?? ListensCacheManager.Instance;
         _listenBrainzClient = listenBrainzClient ??

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -132,7 +132,8 @@ public class ResubmitListensTask : IScheduledTask
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                await _listenBrainzClient.SendListensAsync(userConfig, chunkToSubmit, cancellationToken);
+                // var convertedChunk = ToListens(chunkToSubmit);
+                // await _listenBrainzClient.SendListensAsync(userConfig, convertedChunk, cancellationToken);
                 await _listensCache.RemoveListensAsync(userId, listenChunk);
                 await _listensCache.SaveAsync();
             }

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -122,7 +122,7 @@ public class ResubmitListensTask : IScheduledTask
         return TimeSpan.TicksPerDay + (randomMinute * TimeSpan.TicksPerMinute);
     }
 
-    private async Task SubmitListensForUser(
+    internal async Task SubmitListensForUser(
         PluginConfiguration pluginConfig,
         Guid userId,
         CancellationToken cancellationToken)

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -1,4 +1,3 @@
-using Jellyfin.Plugin.ListenBrainz.Api.Models;
 using Jellyfin.Plugin.ListenBrainz.Api.Resources;
 using Jellyfin.Plugin.ListenBrainz.Common.Extensions;
 using Jellyfin.Plugin.ListenBrainz.Configuration;
@@ -152,7 +151,7 @@ public class ResubmitListensTask : IScheduledTask
 
                     try
                     {
-                        var convertedListen = ToListen(processedListen);
+                        var convertedListen = _libraryManager.ToListen(processedListen);
                         _listensCache.RemoveListen(userId, processedListen);
                         return convertedListen;
                     }
@@ -202,22 +201,5 @@ public class ResubmitListensTask : IScheduledTask
         }
 
         return listen;
-    }
-
-    /// <summary>
-    /// Convert a <see cref="StoredListen"/> to <see cref="Listen"/>s.
-    /// </summary>
-    /// <param name="storedListen">Stored listen to convert.</param>
-    /// <returns>Converted listens.</returns>
-    private Listen? ToListen(StoredListen storedListen)
-    {
-        if (_libraryManager is null)
-        {
-            throw new InvalidOperationException("Library manager is not available");
-        }
-
-        var baseItem = _libraryManager.GetItemById(storedListen.Id);
-        var audio = (Audio?)baseItem;
-        return audio?.AsListen(storedListen.ListenedAt, storedListen.Metadata);
     }
 }

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Extensions/LibraryManagerExtensionsTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Extensions/LibraryManagerExtensionsTests.cs
@@ -1,0 +1,46 @@
+using System;
+using Jellyfin.Plugin.ListenBrainz.Common;
+using Jellyfin.Plugin.ListenBrainz.Dtos;
+using Jellyfin.Plugin.ListenBrainz.Extensions;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.ListenBrainz.Tests.Extensions;
+
+public class LibraryManagerExtensionsTests
+{
+    private readonly Mock<ILibraryManager> _libraryManagerMock = new();
+
+    [Fact]
+    public void ToListen_ItemIsNotAudio()
+    {
+        var itemId = Guid.NewGuid();
+        var notAudio = new Movie { Id = itemId };
+        var storedListen = new StoredListen { Id = itemId };
+        _libraryManagerMock.Setup(lm => lm.GetItemById(storedListen.Id)).Returns(notAudio);
+
+        var result = _libraryManagerMock.Object.ToListen(storedListen);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ToListen_ItemIsAudio()
+    {
+        var itemId = Guid.NewGuid();
+        var audio = new Audio { Id = itemId };
+        var listenTs = DateUtils.CurrentTimestamp;
+        var storedListen = new StoredListen
+        {
+            Id = itemId,
+            ListenedAt = listenTs
+        };
+
+        _libraryManagerMock.Setup(lm => lm.GetItemById(storedListen.Id)).Returns(audio);
+
+        var result = _libraryManagerMock.Object.ToListen(storedListen);
+        Assert.NotNull(result);
+    }
+}

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.7.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/MockPlugin.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/MockPlugin.cs
@@ -1,0 +1,91 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.ListenBrainz.Configuration;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Jellyfin.Plugin.ListenBrainz.Tests;
+
+public class MockPlugin : Plugin
+{
+    public readonly Mock<IApplicationPaths> _pathsMock;
+    public readonly Mock<IXmlSerializer> _xmlSerializerMock;
+    public readonly Mock<ISessionManager> _sessionManagerMock;
+    public readonly Mock<ILoggerFactory> _loggerFactoryMock;
+    public readonly Mock<IHttpClientFactory> _clientFactoryMock;
+    public readonly Mock<IUserDataManager> _userDataManagerMock;
+    public readonly Mock<ILibraryManager> _libraryManagerMock;
+    public readonly Mock<IUserManager> _userManagerMock;
+
+    public MockPlugin(
+        Mock<IApplicationPaths> paths,
+        Mock<IXmlSerializer> xmlSerializer,
+        Mock<ISessionManager> sessionManager,
+        Mock<ILoggerFactory> loggerFactory,
+        Mock<IHttpClientFactory> clientFactory,
+        Mock<IUserDataManager> userDataManager,
+        Mock<ILibraryManager> libraryManager,
+        Mock<IUserManager> userManager,
+        Mock<IHostedService> pluginService) : base(
+        paths.Object,
+        xmlSerializer.Object,
+        sessionManager.Object,
+        loggerFactory.Object,
+        clientFactory.Object,
+        userDataManager.Object,
+        libraryManager.Object,
+        userManager.Object,
+        pluginService.Object)
+    {
+        _pathsMock = paths;
+        _xmlSerializerMock = xmlSerializer;
+        _sessionManagerMock = sessionManager;
+        _loggerFactoryMock = loggerFactory;
+        _clientFactoryMock = clientFactory;
+        _userDataManagerMock = userDataManager;
+        _libraryManagerMock = libraryManager;
+        _userManagerMock = userManager;
+    }
+
+    public static MockPlugin Init(
+        Mock<IApplicationPaths> pathsMock,
+        Mock<IXmlSerializer> xmlSerializerMock,
+        Mock<ISessionManager> sessionManagerMock,
+        Mock<ILoggerFactory> loggerFactoryMock,
+        Mock<IHttpClientFactory> clientFactoryMock,
+        Mock<IUserDataManager> userDataManagerMock,
+        Mock<ILibraryManager> libraryManagerMock,
+        Mock<IUserManager> userManagerMock,
+        Mock<IHostedService> pluginServiceMock,
+        PluginConfiguration configuration)
+    {
+        // Necessary setup or plugin instance crashes
+        pathsMock.Setup(p => p.PluginConfigurationsPath).Returns("some-path");
+        pathsMock.Setup(p => p.PluginsPath).Returns("some-path");
+
+        xmlSerializerMock
+            .Setup(x => x.DeserializeFromFile(typeof(PluginConfiguration), It.IsAny<string>()))
+            .Returns(configuration);
+
+        pluginServiceMock
+            .Setup(s => s.StartAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        return new MockPlugin(
+            pathsMock,
+            xmlSerializerMock,
+            sessionManagerMock,
+            loggerFactoryMock,
+            clientFactoryMock,
+            userDataManagerMock,
+            libraryManagerMock,
+            userManagerMock,
+            pluginServiceMock);
+    }
+}

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
@@ -118,6 +118,18 @@ public class ResubmitListensTaskTests
     }
 
     [Fact]
+    public void IsValidListen_ShouldCatchException()
+    {
+        var listen = GetStoredListens()[0];
+
+        _libraryManagerMock
+            .Setup(lm => lm.GetItemById(listen.Id))
+            .Throws<Exception>();
+
+        Assert.False(_task.IsValidListen(listen));
+    }
+
+    [Fact]
     public void UpdateMetadataIfNecessary_ShouldNotDoAnythingIfRecordingMbidIsPresent()
     {
         var listen = GetStoredListens()[0];
@@ -159,6 +171,23 @@ public class ResubmitListensTaskTests
 
         var updatedListen = _task.UpdateMetadataIfNecessary(listen, CancellationToken.None);
         Assert.Equal("new-mbid", updatedListen?.Metadata?.RecordingMbid);
+    }
+
+    [Fact]
+    public void UpdateMetadataIfNecessary_ShouldCatchException()
+    {
+        var listen = GetStoredListens()[0];
+
+        _libraryManagerMock
+            .Setup(lm => lm.GetItemById(listen.Id))
+            .Returns(new Audio());
+
+        _musicBrainzClientMock
+            .Setup(mb => mb.GetAudioItemMetadata(It.IsAny<Audio>()))
+            .Throws<Exception>();
+
+        var gotListen = _task.UpdateMetadataIfNecessary(listen, CancellationToken.None);
+        Assert.Equal(listen, gotListen);
     }
 
     [Fact]

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
@@ -1,0 +1,76 @@
+using System.Net.Http;
+using Jellyfin.Plugin.ListenBrainz.Interfaces;
+using System;
+using Jellyfin.Plugin.ListenBrainz.Configuration;
+using Jellyfin.Plugin.ListenBrainz.Tasks;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.ListenBrainz.Tests.Tasks;
+
+public class ResubmitListensTaskTests
+{
+    private readonly Mock<ILoggerFactory> _loggerFactoryMock;
+    private readonly Mock<IHttpClientFactory> _clientFactoryMock;
+    private readonly Mock<ILibraryManager> _libraryManagerMock;
+    private readonly Mock<IUserManager> _userManagerMock;
+    private readonly Mock<IListensCacheManager> _listensCacheManagerMock;
+    private readonly Mock<IListenBrainzClient> _listenBrainzClientMock;
+    private readonly Mock<IMusicBrainzClient> _musicBrainzClientMock;
+    private readonly Plugin _plugin;
+    private readonly ResubmitListensTask _task;
+
+    public ResubmitListensTaskTests()
+    {
+        _loggerFactoryMock = new Mock<ILoggerFactory>();
+        _clientFactoryMock = new Mock<IHttpClientFactory>();
+        _libraryManagerMock = new Mock<ILibraryManager>();
+        _userManagerMock = new Mock<IUserManager>();
+        _listensCacheManagerMock = new Mock<IListensCacheManager>();
+        _listenBrainzClientMock = new Mock<IListenBrainzClient>();
+        _musicBrainzClientMock = new Mock<IMusicBrainzClient>();
+        _task = new ResubmitListensTask(
+            _loggerFactoryMock.Object,
+            _clientFactoryMock.Object,
+            _userManagerMock.Object,
+            _libraryManagerMock.Object,
+            _listensCacheManagerMock.Object,
+            _listenBrainzClientMock.Object,
+            _musicBrainzClientMock.Object);
+
+        _plugin = MockPlugin.Init(
+            new Mock<IApplicationPaths>(),
+            new Mock<IXmlSerializer>(),
+            new Mock<ISessionManager>(),
+            _loggerFactoryMock,
+            _clientFactoryMock,
+            new Mock<IUserDataManager>(),
+            _libraryManagerMock,
+            _userManagerMock,
+            new Mock<IHostedService>(),
+            new PluginConfiguration());
+    }
+
+    [Fact]
+    public void GetInterval_ReturnValidInterval()
+    {
+        var interval = ResubmitListensTask.GetInterval();
+        // Should be between 24h and 24h50m
+        Assert.True(interval > TimeSpan.TicksPerDay);
+        Assert.True(interval <= TimeSpan.TicksPerDay + (50 * TimeSpan.TicksPerMinute));
+    }
+
+    [Fact]
+    public void GetInterval_ConsecutiveCallsReturnDifferentValues()
+    {
+        var interval1 = ResubmitListensTask.GetInterval();
+        var interval2 = ResubmitListensTask.GetInterval();
+        Assert.NotEqual(interval1, interval2);
+    }
+}

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
@@ -127,7 +127,7 @@ public class ResubmitListensTaskTests
             .Setup(lm => lm.GetItemById(listen.Id))
             .Returns(new Audio());
 
-        var updatedListen = _task.UpdateMetadataIfNecessary(listen);
+        var updatedListen = _task.UpdateMetadataIfNecessary(listen, CancellationToken.None);
         Assert.Equal("mbid-not-changed", updatedListen?.Metadata?.RecordingMbid);
     }
 
@@ -140,7 +140,7 @@ public class ResubmitListensTaskTests
             .Setup(lm => lm.GetItemById(listen.Id))
             .Returns(new Movie());
 
-        Assert.Null(_task.UpdateMetadataIfNecessary(listen));
+        Assert.Null(_task.UpdateMetadataIfNecessary(listen, CancellationToken.None));
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class ResubmitListensTaskTests
             .Setup(mbc => mbc.GetAudioItemMetadata(It.IsAny<Audio>()))
             .Returns(new AudioItemMetadata { RecordingMbid = "new-mbid" });
 
-        var updatedListen = _task.UpdateMetadataIfNecessary(listen);
+        var updatedListen = _task.UpdateMetadataIfNecessary(listen, CancellationToken.None);
         Assert.Equal("new-mbid", updatedListen?.Metadata?.RecordingMbid);
     }
 

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
@@ -67,14 +67,12 @@ public class ResubmitListensTaskTests
         new()
         {
             Id = Guid.NewGuid(),
-            ListenedAt = 12345567890,
-            Metadata = new AudioItemMetadata { RecordingMbid = "mbid-1" }
+            ListenedAt = 12345567890
         },
         new()
         {
             Id = Guid.NewGuid(),
-            ListenedAt = 12345567891,
-            Metadata = new AudioItemMetadata { RecordingMbid = "mbid-2" }
+            ListenedAt = 12345567891
         }
     ];
 

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
@@ -126,8 +126,12 @@ public class ResubmitListensTaskTests
         var listen = GetStoredListens()[0];
         listen.Metadata = new AudioItemMetadata { RecordingMbid = "mbid-not-changed" };
 
-        _task.UpdateMetadataIfNecessary(listen);
-        Assert.Equal("mbid-not-changed", listen.Metadata.RecordingMbid);
+        _libraryManagerMock
+            .Setup(lm => lm.GetItemById(listen.Id))
+            .Returns(new Audio());
+
+        var updatedListen = _task.UpdateMetadataIfNecessary(listen);
+        Assert.Equal("mbid-not-changed", updatedListen?.Metadata?.RecordingMbid);
     }
 
     [Fact]
@@ -146,6 +150,7 @@ public class ResubmitListensTaskTests
     public void UpdateMetadataIfNecessary_ShouldUpdateMetadata()
     {
         var listen = GetStoredListens()[0];
+        listen.Metadata = new AudioItemMetadata { RecordingMbid = string.Empty };
 
         _libraryManagerMock
             .Setup(lm => lm.GetItemById(listen.Id))
@@ -155,8 +160,8 @@ public class ResubmitListensTaskTests
             .Setup(mbc => mbc.GetAudioItemMetadata(It.IsAny<Audio>()))
             .Returns(new AudioItemMetadata { RecordingMbid = "new-mbid" });
 
-        _task.UpdateMetadataIfNecessary(listen);
-        Assert.Equal("new-mbid", listen.Metadata?.RecordingMbid);
+        var updatedListen = _task.UpdateMetadataIfNecessary(listen);
+        Assert.Equal("new-mbid", updatedListen?.Metadata?.RecordingMbid);
     }
 
     [Fact]

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
@@ -25,7 +25,6 @@ public class ResubmitListensTaskTests
     private readonly Mock<ILoggerFactory> _loggerFactoryMock;
     private readonly Mock<IHttpClientFactory> _clientFactoryMock;
     private readonly Mock<ILibraryManager> _libraryManagerMock;
-    private readonly Mock<IUserManager> _userManagerMock;
     private readonly Mock<IListensCacheManager> _listensCacheManagerMock;
     private readonly Mock<IListenBrainzClient> _listenBrainzClientMock;
     private readonly Mock<IMusicBrainzClient> _musicBrainzClientMock;
@@ -40,7 +39,6 @@ public class ResubmitListensTaskTests
 
         _clientFactoryMock = new Mock<IHttpClientFactory>();
         _libraryManagerMock = new Mock<ILibraryManager>();
-        _userManagerMock = new Mock<IUserManager>();
         _listensCacheManagerMock = new Mock<IListensCacheManager>();
         _listenBrainzClientMock = new Mock<IListenBrainzClient>();
         _musicBrainzClientMock = new Mock<IMusicBrainzClient>();
@@ -48,7 +46,6 @@ public class ResubmitListensTaskTests
         _task = new ResubmitListensTask(
             _loggerFactoryMock.Object,
             _clientFactoryMock.Object,
-            _userManagerMock.Object,
             _libraryManagerMock.Object,
             _listensCacheManagerMock.Object,
             _listenBrainzClientMock.Object,

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/ResubmitListenTaskTests.cs
@@ -22,7 +22,6 @@ namespace Jellyfin.Plugin.ListenBrainz.Tests.Tasks;
 
 public class ResubmitListensTaskTests
 {
-    private readonly Mock<ILoggerFactory> _loggerFactoryMock;
     private readonly Mock<IHttpClientFactory> _clientFactoryMock;
     private readonly Mock<ILibraryManager> _libraryManagerMock;
     private readonly Mock<IListensCacheManager> _listensCacheManagerMock;
@@ -32,8 +31,8 @@ public class ResubmitListensTaskTests
 
     public ResubmitListensTaskTests()
     {
-        _loggerFactoryMock = new Mock<ILoggerFactory>();
-        _loggerFactoryMock
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock
             .Setup(lf => lf.CreateLogger(It.IsAny<string>()))
             .Returns(new NullLogger<ResubmitListensTask>());
 
@@ -44,7 +43,7 @@ public class ResubmitListensTaskTests
         _musicBrainzClientMock = new Mock<IMusicBrainzClient>();
 
         _task = new ResubmitListensTask(
-            _loggerFactoryMock.Object,
+            loggerFactoryMock.Object,
             _clientFactoryMock.Object,
             _libraryManagerMock.Object,
             _listensCacheManagerMock.Object,


### PR DESCRIPTION
Improve cached listen resubmission, now drops invalid listens selectively instead of a whole chunk.

Fixes #115 