### PR TITLE
Compatibility for Jellyfin 10.11.x

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
 version: "6.0.0.0"
-targetAbi: "10.10.0.0"
+targetAbi: "10.11.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."
 description: >

--- a/build.yaml
+++ b/build.yaml
@@ -16,5 +16,5 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.Http.dll"
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
-  Fix
-    - Incorrect timestamp and meta-data for repeated listens in cache (#113 @Maxr1998)
+  Maintenance
+    - Compatibility for Jellyfin 10.11.0

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "5.0.2.0"
+version: "6.0.0.0"
 targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Track your music habits with ListenBrainz."


### PR DESCRIPTION
All necessary plugin changes for next Jellyfin version.

Not to be merged until a stable 10.11.0 is out.