### PR TITLE
10.11 unstable fix as of the end of March 2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       dotnet-target:
         type: string
         required: false
-        default: "net8.0"
+        default: "net9.0"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ dotnet publish -c Release
 ```
 
 Once the build is completed, the compiled DLLs should be available at:
-`src/Jellyfin.Plugin.Listenbrainz/bin/<Debug|Release>/net8.0/`
+`src/Jellyfin.Plugin.Listenbrainz/bin/<Debug|Release>/net9.0/`
 
 To install the plugin for the first time, copy all **DLL** files starting with `Jellyfin.Plugin.ListenBrainz` to the
 plugin directory in your Jellyfin config directory (`${CONFIG_DIR}/plugins/ListenBrainz_1.0.0.0`).

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
 version: "5.0.2.0"
 targetAbi: "10.10.0.0"
-framework: "net8.0"
+framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."
 description: >
   A plugin to send your music listening activity on Jellyfin to ListenBrainz.

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Jellyfin.Plugin.ListenBrainz.Api.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Jellyfin.Plugin.ListenBrainz.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,11 +11,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
       <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+      <Reference Include="/home/moisespr123/repos/jellyfin/Jellyfin.Server/bin/Debug/net9.0/MediaBrowser.Controller.dll" Version="10.11.0" />
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/Jellyfin.Plugin.ListenBrainz.Common/Jellyfin.Plugin.ListenBrainz.Common.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Common/Jellyfin.Plugin.ListenBrainz.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Jellyfin.Plugin.ListenBrainz.Http/Jellyfin.Plugin.ListenBrainz.Http.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.Http/Jellyfin.Plugin.ListenBrainz.Http.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
         <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
         <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
         <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />

--- a/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
       <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
       <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
       <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />

--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/LibraryManagerExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/LibraryManagerExtensions.cs
@@ -1,3 +1,4 @@
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;

--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/UserExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/UserExtensions.cs
@@ -1,4 +1,4 @@
-using Jellyfin.Data.Entities;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.ListenBrainz.Configuration;
 using Jellyfin.Plugin.ListenBrainz.Exceptions;
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
+++ b/src/Jellyfin.Plugin.ListenBrainz/Jellyfin.Plugin.ListenBrainz.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,9 +11,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Jellyfin.Controller" Version="10.10.0" />
-      <PackageReference Include="Jellyfin.Data" Version="10.10.0" />
-      <PackageReference Include="Jellyfin.Model" Version="10.10.0" />
+     <Reference Include="/home/moisespr123/repos/jellyfin/Jellyfin.Server/bin/Debug/net9.0/MediaBrowser.Common.dll" Version="10.11.0" />
+      <Reference Include="/home/moisespr123/repos/jellyfin/Jellyfin.Server/bin/Debug/net9.0/MediaBrowser.Controller.dll" Version="10.11.0" />
+      <Reference Include="/home/moisespr123/repos/jellyfin/Jellyfin.Server/bin/Debug/net9.0/Jellyfin.Database.Implementations.dll" Version="10.11.0" />
+      <Reference Include="/home/moisespr123/repos/jellyfin/Jellyfin.Server/bin/Debug/net9.0/Jellyfin.Data.dll" Version="10.11.0" />
+      <Reference Include="/home/moisespr123/repos/jellyfin/Jellyfin.Server/bin/Debug/net9.0/MediaBrowser.Model.dll" Version="10.11.0" />
       <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
       <PackageReference Include="SmartAnalyzers.ExceptionAnalyzer" Version="1.0.10" />
       <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" />
@@ -21,6 +23,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/PluginImplementation.cs
@@ -1,4 +1,4 @@
-using Jellyfin.Data.Entities;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.ListenBrainz.Api.Resources;
 using Jellyfin.Plugin.ListenBrainz.Common;
 using Jellyfin.Plugin.ListenBrainz.Configuration;

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -24,7 +24,6 @@ public class LovedTracksSyncTask : IScheduledTask
     private readonly IMusicBrainzClient _musicBrainzClient;
     private readonly ILibraryManager _libraryManager;
     private readonly IUserManager _userManager;
-    private readonly IUserDataRepository _repository;
     private readonly IUserDataManager _userDataManager;
     private bool _reenableImmediateSync;
     private double _progress;
@@ -37,14 +36,12 @@ public class LovedTracksSyncTask : IScheduledTask
     /// <param name="clientFactory">HTTP client factory.</param>
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="userManager">User manager.</param>
-    /// <param name="dataRepository">Data repository.</param>
     /// <param name="dataManager">User data manager.</param>
     public LovedTracksSyncTask(
         ILoggerFactory loggerFactory,
         IHttpClientFactory clientFactory,
         ILibraryManager libraryManager,
         IUserManager userManager,
-        IUserDataRepository dataRepository,
         IUserDataManager dataManager)
     {
         _logger = loggerFactory.CreateLogger($"{Plugin.LoggerCategory}.LovedSyncTask");
@@ -52,7 +49,6 @@ public class LovedTracksSyncTask : IScheduledTask
         _musicBrainzClient = ClientUtils.GetMusicBrainzClient(_logger, clientFactory);
         _libraryManager = libraryManager;
         _userManager = userManager;
-        _repository = dataRepository;
         _userDataManager = dataManager;
     }
 
@@ -209,11 +205,7 @@ public class LovedTracksSyncTask : IScheduledTask
             _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.UpdateUserRating, cancellationToken);
             return;
         }
-
-        foreach (var key in item.GetUserDataKeys())
-        {
-            _repository.SaveUserData(user.InternalId, key, userData, cancellationToken);
-        }
+        _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.UpdateUserRating, cancellationToken);
 
         _logger.LogDebug("Item {Name} has been marked as favorite for user {User}", item.Name, user.Username);
     }

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -205,6 +205,7 @@ public class LovedTracksSyncTask : IScheduledTask
             _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.UpdateUserRating, cancellationToken);
             return;
         }
+
         _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.UpdateUserRating, cancellationToken);
 
         _logger.LogDebug("Item {Name} has been marked as favorite for user {User}", item.Name, user.Username);

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/LovedTracksSyncTask.cs
@@ -1,4 +1,5 @@
-using Jellyfin.Data.Entities;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.ListenBrainz.Common.Extensions;
 using Jellyfin.Plugin.ListenBrainz.Configuration;
@@ -205,8 +206,6 @@ public class LovedTracksSyncTask : IScheduledTask
             _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.UpdateUserRating, cancellationToken);
             return;
         }
-
-        _userDataManager.SaveUserData(user, item, userData, UserDataSaveReason.UpdateUserRating, cancellationToken);
 
         _logger.LogDebug("Item {Name} has been marked as favorite for user {User}", item.Name, user.Username);
     }

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/ResubmitListensTask.cs
@@ -98,7 +98,7 @@ public class ResubmitListensTask : IScheduledTask
         {
             new TaskTriggerInfo
             {
-                Type = TaskTriggerInfo.TriggerInterval,
+                Type = TaskTriggerInfoType.IntervalTrigger,
                 IntervalTicks = GetInterval()
             }
         };

--- a/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/Jellyfin.Plugin.ListenBrainz.Api.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Api.Tests/Jellyfin.Plugin.ListenBrainz.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Common.Tests/Jellyfin.Plugin.ListenBrainz.Common.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Common.Tests/Jellyfin.Plugin.ListenBrainz.Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/Jellyfin.Plugin.ListenBrainz.Http.Tests/Jellyfin.Plugin.ListenBrainz.Http.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Http.Tests/Jellyfin.Plugin.ListenBrainz.Http.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests/Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Jellyfin.Plugin.ListenBrainz.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
@@ -18,6 +18,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <Reference Include="/home/moisespr123/repos/jellyfin/Jellyfin.Server/bin/Debug/net9.0/MediaBrowser.Controller.dll" Version="10.11.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Some more breaking changes were introduced in the latest 10.11 codebase.

Most notably, some references in Jellyfin.Data were moved to Jellyfin.Database for both Entities and Enums. Some other changes were made as well.

Due to the 10.11 changes not yet being available in Nuget, I had to reference them with the locally compiled Jellyfin files, which is why there are changes in the .csproj files. These can be changed back once Jellyfin pushes the final 10.11 changes but in the meantime, I expect there may be further breaking changes due to their current jellyfin.db EFCore refactor.

At least with these changes, I can at least submit the songs again to ListenBrainz.

These past couple of week updates broke a lot of plugins, so doing something here to get this working 😁