### PR TITLE
feat(favorite): Sync album like as track favorite

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz/Services/DefaultFavoriteSyncService.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Services/DefaultFavoriteSyncService.cs
@@ -90,6 +90,7 @@ public class DefaultFavoriteSyncService : IFavoriteSyncService
         }
 
         var userItemData = _userDataManager.GetUserData(jellyfinUser, item);
+        var userParentItemData = _userDataManager.GetUserData(jellyfinUser, item.GetParent());
 
         var recordingMbid = item.ProviderIds.GetValueOrDefault("MusicBrainzRecording");
         if (string.IsNullOrEmpty(recordingMbid) && _pluginConfigService.IsMusicBrainzEnabled)
@@ -121,7 +122,7 @@ public class DefaultFavoriteSyncService : IFavoriteSyncService
         try
         {
             _logger.LogInformation("Attempting to sync favorite status");
-            _listenBrainzClient.SendFeedback(userConfig, userItemData.IsFavorite, recordingMbid, recordingMsid);
+            _listenBrainzClient.SendFeedback(userConfig, userItemData.IsFavorite || userParentItemData.IsFavorite, recordingMbid, recordingMsid);
             _logger.LogInformation("Favorite sync has been successful");
         }
         catch (Exception e)


### PR DESCRIPTION
Closes https://github.com/lyarenei/jellyfin-plugin-listenbrainz/issues/142

I have to admit I spent way too long figuring out how to build the plugin, jellyfin, jellyfin-web and so on. In the end I was able to confirm that this change works with liked albums. I suspect this will also work with playlists. It could also be extended to iterate all parents, so a liked artist would be considered as a favorite as well (although I'm not sure if this really makes sense).