### PR TITLE
Playlist sync improvements

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.3.0.6"
+version: "6.3.0.7"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.3.0.5"
+version: "6.3.0.6"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -18,3 +18,5 @@ artifacts:
 changelog: >
   Maintenance:
     - Config page redesign
+    - Fix potential playlist duplication
+    - Use playlist tags instead of prefix in playlist names

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.3.0.4"
+version: "6.3.0.5"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.3.0.7"
+version: "6.3.0.8"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.3.0.8"
+version: "6.3.0.9"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/PlaylistMapping.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/PlaylistMapping.cs
@@ -1,0 +1,25 @@
+namespace Jellyfin.Plugin.ListenBrainz.Configuration;
+
+/// <summary>
+/// Mapping between a ListenBrainz playlist and its Jellyfin counterpart.
+/// </summary>
+public class PlaylistMapping
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaylistMapping"/> class.
+    /// </summary>
+    public PlaylistMapping()
+    {
+        ListenBrainzPlaylistId = string.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the ListenBrainz playlist ID.
+    /// </summary>
+    public string ListenBrainzPlaylistId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Jellyfin playlist ID.
+    /// </summary>
+    public Guid JellyfinPlaylistId { get; set; }
+}

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/UserConfig.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/UserConfig.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Xml.Serialization;
@@ -19,6 +21,7 @@ public class UserConfig
         UserName = string.Empty;
         IsBackupEnabled = false;
         IsStrictModeEnabled = false;
+        PlaylistMappings = new Collection<PlaylistMapping>();
     }
 
     /// <summary>
@@ -68,6 +71,12 @@ public class UserConfig
     /// Gets or sets a ListenBrainz username.
     /// </summary>
     public string UserName { get; set; }
+
+    /// <summary>
+    /// Gets or sets mappings between ListenBrainz playlists and synced Jellyfin playlists.
+    /// </summary>
+    [SuppressMessage("Warning", "CA2227", Justification = "Needed for deserialization")]
+    public Collection<PlaylistMapping> PlaylistMappings { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether listens should be backed up.

--- a/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IPluginConfigService.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IPluginConfigService.cs
@@ -66,4 +66,21 @@ public interface IPluginConfigService
     /// <param name="jellyfinUserId">ID of the Jellyfin user.</param>
     /// <returns>User configuration. Null if it does not exist.</returns>
     public UserConfig? GetUserConfig(Guid jellyfinUserId);
+
+    /// <summary>
+    /// Gets a matching Jellyfin playlist ID for a ListenBrainz playlist ID.
+    /// </summary>
+    /// <param name="jellyfinUserId">ID of the Jellyfin user.</param>
+    /// <param name="playlistId">ListenBrainz playlist ID.</param>
+    /// <returns>Mapped Jellyfin playlist ID. Null if it does not exist.</returns>
+    Guid? GetPlaylistId(Guid jellyfinUserId, string playlistId);
+
+    /// <summary>
+    /// Adds or updates a playlist mapping for a Jellyfin user.
+    /// </summary>
+    /// <param name="jellyfinUserId">ID of the Jellyfin user.</param>
+    /// <param name="listenBrainzPlaylistId">ListenBrainz playlist ID.</param>
+    /// <param name="jellyfinPlaylistId">Jellyfin playlist ID.</param>
+    /// <returns>Operation success.</returns>
+    bool SetPlaylistMapping(Guid jellyfinUserId, string listenBrainzPlaylistId, Guid jellyfinPlaylistId);
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/constants.ts
+++ b/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/constants.ts
@@ -12,6 +12,7 @@ export const userDefaults: PluginUserConfig = {
     IsStrictModeEnabled: false,
     IsBackupEnabled: false,
     JellyfinUserId: "",
+    PlaylistMappings: [],
     UserName: "",
 };
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/eventHooks/submit.ts
+++ b/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/eventHooks/submit.ts
@@ -142,11 +142,17 @@ async function saveUserConfig(view: HTMLElement, currentPluginConfig: PluginConf
         // We don't care if validation failed
     }
 
+    const updatedUserConfig = {
+        ...currentUserConfig,
+        ...newUserConfig,
+        PlaylistMappings: currentUserConfig.PlaylistMappings ?? [],
+    };
+
     const updatedPluginConfig: PluginConfiguration = {
         ...currentPluginConfig,
         UserConfigs: [
             ...currentPluginConfig.UserConfigs.filter((config) => config.JellyfinUserId !== selectedUserId),
-            { ...newUserConfig },
+            updatedUserConfig,
         ],
     };
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/formHelpers.ts
+++ b/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/formHelpers.ts
@@ -35,6 +35,7 @@ export function getUserConfigFormData(view: HTMLElement): PluginUserConfig {
         IsPlaylistsSyncEnabled: elements.playlistsSync.checked,
         IsStrictModeEnabled: elements.strictMode.checked,
         JellyfinUserId: elements.userDropdown.value,
+        PlaylistMappings: [],
         UserName: "",
     };
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/types.ts
+++ b/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/types.ts
@@ -21,6 +21,11 @@ export interface PluginConfiguration {
     UserConfigs: PluginUserConfig[];
 }
 
+export interface PlaylistMapping {
+    JellyfinPlaylistId: string;
+    ListenBrainzPlaylistId: string;
+}
+
 // Plugin user configuration.
 // The keys must match the fields of UserConfig class.
 export interface PluginUserConfig {
@@ -31,6 +36,7 @@ export interface PluginUserConfig {
     IsPlaylistsSyncEnabled: boolean;
     IsStrictModeEnabled: boolean;
     JellyfinUserId: string;
+    PlaylistMappings: PlaylistMapping[];
     UserName: string;
 }
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Services/DefaultPluginConfigService.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Services/DefaultPluginConfigService.cs
@@ -74,4 +74,50 @@ public class DefaultPluginConfigService : IPluginConfigService
 
         return userConfig;
     }
+
+    /// <inheritdoc />
+    public Guid? GetPlaylistId(Guid jellyfinUserId, string playlistId)
+    {
+        var userConfig = GetUserConfig(jellyfinUserId);
+        var mapping = userConfig?
+            .PlaylistMappings
+            .FirstOrDefault(m => string.Equals(m.ListenBrainzPlaylistId, playlistId, StringComparison.Ordinal));
+
+        return mapping?.JellyfinPlaylistId;
+    }
+
+    /// <inheritdoc />
+    public bool SetPlaylistMapping(Guid jellyfinUserId, string listenBrainzPlaylistId, Guid jellyfinPlaylistId)
+    {
+        var userConfig = GetUserConfig(jellyfinUserId);
+        if (userConfig is null)
+        {
+            return false;
+        }
+
+        var mapping = userConfig
+            .PlaylistMappings
+            .FirstOrDefault(m =>
+                string.Equals(m.ListenBrainzPlaylistId, listenBrainzPlaylistId, StringComparison.Ordinal));
+
+        if (mapping is null)
+        {
+            userConfig.PlaylistMappings.Add(new PlaylistMapping
+            {
+                ListenBrainzPlaylistId = listenBrainzPlaylistId,
+                JellyfinPlaylistId = jellyfinPlaylistId,
+            });
+        }
+        else if (mapping.JellyfinPlaylistId == jellyfinPlaylistId)
+        {
+            return true;
+        }
+        else
+        {
+            mapping.JellyfinPlaylistId = jellyfinPlaylistId;
+        }
+
+        Plugin.UpdateConfig(Config);
+        return true;
+    }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -128,6 +128,7 @@ public class SyncPlaylistsTask : IScheduledTask
                     continue;
                 }
 
+                await MigratePlaylists(userConfig, cancellationToken);
                 await HandlePlaylistSync(progress, userConfig, cancellationToken);
             }
         }
@@ -135,6 +136,110 @@ public class SyncPlaylistsTask : IScheduledTask
         {
             _logger.LogInformation("Playlist sync task has been cancelled");
             progress.Report(100);
+        }
+    }
+
+    private async Task MigratePlaylists(UserConfig userConfig, CancellationToken cancellationToken)
+    {
+        var user = _userManager.GetUserById(userConfig.JellyfinUserId);
+        if (user is null)
+        {
+            _logger.LogError("User with ID {UserId} does not exist", userConfig.JellyfinUserId);
+            return;
+        }
+
+        var listenBrainzPlaylists = (
+            await _listenBrainzClient.GetCreatedForPlaylistsAsync(
+                userConfig,
+                Limits.MaxItemsPerGet,
+                cancellationToken)
+        ).ToList();
+
+        var playlistsToMigrate = _libraryManager
+            .GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = [BaseItemKind.Playlist],
+                User = user,
+            })
+            .Where(p => p.Name.StartsWith(PlaylistPrefix, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (playlistsToMigrate.Count == 0)
+        {
+            _logger.LogDebug("No playlists to migrate found for user {Username}", userConfig.UserName);
+            return;
+        }
+
+        _logger.LogDebug(
+            "Found {LegacyPlaylistCount} not migrated playlists for user {Username}",
+            playlistsToMigrate.Count,
+            userConfig.UserName);
+
+        var playlistsByTitle = listenBrainzPlaylists
+            .GroupBy(playlist => playlist.Title, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var playlistToMigrate in playlistsToMigrate)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var titleWithoutPrefix = playlistToMigrate.Name.Substring(PlaylistPrefix.Length).Trim();
+
+            _logger.LogDebug("Attempting to migrate playlist {PlaylistName}", playlistToMigrate.Name);
+
+            if (!playlistsByTitle.TryGetValue(titleWithoutPrefix, out var matchingPlaylists))
+            {
+                // Common for weekly jams playlists from the past
+                _logger.LogInformation(
+                    "Skipping migration of playlist {PlaylistName}: no ListenBrainz playlist found with title {Title}",
+                    playlistToMigrate.Name,
+                    titleWithoutPrefix);
+                continue;
+            }
+
+            if (matchingPlaylists.Count > 1)
+            {
+                // Very old playlists were created by troi-bot and appear to be regenerated in 2026
+                // so not treating this as an error.
+                _logger.LogInformation(
+                    "Playlist {PlaylistName}: title {Title} is ambiguous across {Count} ListenBrainz playlists, picking the most recently created one",
+                    playlistToMigrate.Name,
+                    titleWithoutPrefix,
+                    matchingPlaylists.Count);
+            }
+
+            var matchingPlaylist = matchingPlaylists.OrderByDescending(p => p.CreatedAt).First();
+            var existingMapping = _configService.GetPlaylistId(userConfig.JellyfinUserId, matchingPlaylist.PlaylistId);
+            if (existingMapping.HasValue && existingMapping.Value != playlistToMigrate.Id)
+            {
+                _logger.LogInformation(
+                    "Skipping migration of playlist {PlaylistName}: ListenBrainz playlist {ListenBrainzPlaylistId} is already mapped to Jellyfin playlist {MappedPlaylistId}",
+                    playlistToMigrate.Name,
+                    matchingPlaylist.PlaylistId,
+                    existingMapping.Value);
+                continue;
+            }
+
+            var mappingSaved = _configService.SetPlaylistMapping(
+                userConfig.JellyfinUserId,
+                matchingPlaylist.PlaylistId,
+                playlistToMigrate.Id);
+
+            if (!mappingSaved)
+            {
+                _logger.LogDebug(
+                    "Skipping migration of playlist {PlaylistName}: failed to save mapping for ListenBrainz playlist {ListenBrainzPlaylistId}",
+                    playlistToMigrate.Name,
+                    matchingPlaylist.PlaylistId);
+                continue;
+            }
+
+            await UpdatePlaylistMetadata(playlistToMigrate, titleWithoutPrefix, cancellationToken);
+
+            _logger.LogInformation(
+                "Migrated playlist {PlaylistId} (mapped to ListenBrainz playlist {ListenBrainzPlaylistId})",
+                playlistToMigrate.Id,
+                matchingPlaylist.PlaylistId);
         }
     }
 
@@ -307,7 +412,7 @@ public class SyncPlaylistsTask : IScheduledTask
             _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, createdPlaylistId);
         }
 
-        await SetListenBrainzTag(syncedPlaylist, cancellationToken).ConfigureAwait(false);
+        await UpdatePlaylistMetadata(syncedPlaylist, null, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Successfully synced playlist {Name} with {Count} tracks",
@@ -346,52 +451,38 @@ public class SyncPlaylistsTask : IScheduledTask
     private BaseItem? GetJellyfinPlaylist(User user, UserConfig userConfig, Playlist playlist)
     {
         var playlistId = _configService.GetPlaylistId(userConfig.JellyfinUserId, playlist.PlaylistId);
-        if (playlistId is null)
-        {
-            // Playlist may already exist before mappings were introduced
-            return MigratePlaylist(user, userConfig, playlist);
-        }
-
-        return _playlistManager.GetPlaylistForUser(playlistId.Value, user.Id);
+        return playlistId is null ? null : _playlistManager.GetPlaylistForUser(playlistId.Value, user.Id);
     }
 
-    private BaseItem? MigratePlaylist(User user, UserConfig userConfig, Playlist playlist)
+    private async Task UpdatePlaylistMetadata(
+        BaseItem playlist,
+        string? playlistName,
+        CancellationToken cancellationToken)
     {
-        var legacyPlaylistQuery = new InternalItemsQuery
-        {
-            IncludeItemTypes = [BaseItemKind.Playlist],
-            Name = $"{PlaylistPrefix} {playlist.Title}",
-            User = user,
-        };
+        var didChange = false;
 
-        var existingPlaylist = _libraryManager.GetItemList(legacyPlaylistQuery).FirstOrDefault();
-        if (existingPlaylist is null)
+        if (!string.IsNullOrWhiteSpace(playlistName) &&
+            !string.Equals(playlist.Name, playlistName, StringComparison.Ordinal))
         {
-            return null;
+            playlist.Name = playlistName;
+            didChange = true;
         }
 
-        var ok = _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, existingPlaylist.Id);
-        if (!ok)
+        if (!playlist.Tags.Any(tag => string.Equals(tag, PlaylistTag, StringComparison.OrdinalIgnoreCase)))
         {
-            return null;
+            playlist.Tags =
+            [
+                .. playlist.Tags,
+                PlaylistTag,
+            ];
+
+            didChange = true;
         }
 
-        existingPlaylist.Name = playlist.Title;
-        return existingPlaylist;
-    }
-
-    private async Task SetListenBrainzTag(BaseItem playlist, CancellationToken cancellationToken)
-    {
-        if (playlist.Tags.Any(tag => string.Equals(tag, PlaylistTag, StringComparison.OrdinalIgnoreCase)))
+        if (!didChange)
         {
             return;
         }
-
-        playlist.Tags =
-        [
-            .. playlist.Tags,
-            PlaylistTag,
-        ];
 
         var parent = playlist.ParentId == Guid.Empty
             ? playlist

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -26,6 +26,7 @@ namespace Jellyfin.Plugin.ListenBrainz.Tasks;
 /// </summary>
 public class SyncPlaylistsTask : IScheduledTask
 {
+    private const string PlaylistPrefix = "[LB]";
     private const string PlaylistTag = "ListenBrainz";
 
     private static readonly string[] _defaultAllowedPatches =
@@ -264,7 +265,7 @@ public class SyncPlaylistsTask : IScheduledTask
             playlist.Tracks.Count(),
             playlist.Title);
 
-        var existingPlaylist = GetJellyfinPlaylist(userConfig, playlist.PlaylistId);
+        var existingPlaylist = GetJellyfinPlaylist(user, userConfig, playlist);
         var playlistName = playlist.Title;
         BaseItem? syncedPlaylist;
 
@@ -342,10 +343,33 @@ public class SyncPlaylistsTask : IScheduledTask
             sourcePatch.Contains(patch, StringComparison.InvariantCultureIgnoreCase));
     }
 
-    private BaseItem? GetJellyfinPlaylist(UserConfig userConfig, string listenBrainzPlaylistId)
+    private BaseItem? GetJellyfinPlaylist(User user, UserConfig userConfig, Playlist playlist)
     {
-        var playlistId = _configService.GetPlaylistId(userConfig.JellyfinUserId, listenBrainzPlaylistId);
-        return playlistId is null ? null : _libraryManager.GetItemById(playlistId.Value);
+        var playlistId = _configService.GetPlaylistId(userConfig.JellyfinUserId, playlist.PlaylistId);
+        if (playlistId is not null)
+        {
+            return _libraryManager.GetItemById(playlistId.Value);
+        }
+
+        // Playlist may already exist before mappings were introduced
+        return MigratePlaylist(user, userConfig, playlist);
+    }
+
+    private BaseItem? MigratePlaylist(User user, UserConfig userConfig, Playlist playlist)
+    {
+        var legacyPlaylistQuery = new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.Playlist],
+            Name = $"{PlaylistPrefix} ${playlist.Title}",
+            User = user,
+        };
+        var legacyPlaylist = _libraryManager.GetItemList(legacyPlaylistQuery).FirstOrDefault();
+        if (legacyPlaylist is not null)
+        {
+            _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, legacyPlaylist.Id);
+        }
+
+        return legacyPlaylist;
     }
 
     private async Task SetListenBrainzTag(BaseItem playlist, CancellationToken cancellationToken)

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -280,7 +280,7 @@ public class SyncPlaylistsTask : IScheduledTask
                 Ids = jellyfinPlaylistTracks.Select(i => i.Id).ToArray(),
             });
 
-            syncedPlaylist = _libraryManager.GetItemById(existingPlaylist.Id) ?? existingPlaylist;
+            syncedPlaylist = _playlistManager.GetPlaylistForUser(existingPlaylist.Id, user.Id) ?? existingPlaylist;
         }
         else
         {
@@ -298,7 +298,7 @@ public class SyncPlaylistsTask : IScheduledTask
                 throw new PluginException($"Failed to parse created playlist id '{createdPlaylist.Id}'");
             }
 
-            syncedPlaylist = _libraryManager.GetItemById(createdPlaylistId);
+            syncedPlaylist = _playlistManager.GetPlaylistForUser(createdPlaylistId, user.Id);
             if (syncedPlaylist is null)
             {
                 throw new PluginException($"Failed to load created Jellyfin playlist '{createdPlaylistId}'");
@@ -352,7 +352,7 @@ public class SyncPlaylistsTask : IScheduledTask
             return MigratePlaylist(user, userConfig, playlist);
         }
 
-        return _libraryManager.GetItemById(playlistId.Value);
+        return _playlistManager.GetPlaylistForUser(playlistId.Value, user.Id);
     }
 
     private BaseItem? MigratePlaylist(User user, UserConfig userConfig, Playlist playlist)

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -363,12 +363,20 @@ public class SyncPlaylistsTask : IScheduledTask
             Name = $"{PlaylistPrefix} ${playlist.Title}",
             User = user,
         };
+
         var legacyPlaylist = _libraryManager.GetItemList(legacyPlaylistQuery).FirstOrDefault();
-        if (legacyPlaylist is not null)
+        if (legacyPlaylist is null)
         {
-            _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, legacyPlaylist.Id);
+            return null;
         }
 
+        var ok = _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, legacyPlaylist.Id);
+        if (!ok)
+        {
+            return null;
+        }
+
+        legacyPlaylist.Name = playlist.Title;
         return legacyPlaylist;
     }
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -364,20 +364,20 @@ public class SyncPlaylistsTask : IScheduledTask
             User = user,
         };
 
-        var legacyPlaylist = _libraryManager.GetItemList(legacyPlaylistQuery).FirstOrDefault();
-        if (legacyPlaylist is null)
+        var existingPlaylist = _libraryManager.GetItemList(legacyPlaylistQuery).FirstOrDefault();
+        if (existingPlaylist is null)
         {
             return null;
         }
 
-        var ok = _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, legacyPlaylist.Id);
+        var ok = _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, existingPlaylist.Id);
         if (!ok)
         {
             return null;
         }
 
-        legacyPlaylist.Name = playlist.Title;
-        return legacyPlaylist;
+        existingPlaylist.Name = playlist.Title;
+        return existingPlaylist;
     }
 
     private async Task SetListenBrainzTag(BaseItem playlist, CancellationToken cancellationToken)

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -26,6 +26,8 @@ namespace Jellyfin.Plugin.ListenBrainz.Tasks;
 /// </summary>
 public class SyncPlaylistsTask : IScheduledTask
 {
+    private const string PlaylistTag = "ListenBrainz";
+
     private static readonly string[] _defaultAllowedPatches =
     [
         "weekly-jams",
@@ -193,7 +195,7 @@ public class SyncPlaylistsTask : IScheduledTask
                             userConfig,
                             pl.PlaylistId,
                             cancellationToken);
-                        await SyncPlaylist(user, playlist, allAudioItems, cancellationToken);
+                        await SyncPlaylist(user, userConfig, playlist, allAudioItems, cancellationToken);
                     }
                     catch (Exception e)
                     {
@@ -222,6 +224,7 @@ public class SyncPlaylistsTask : IScheduledTask
 
     private async Task SyncPlaylist(
         User user,
+        UserConfig userConfig,
         Playlist playlist,
         IReadOnlyList<BaseItem> allAudioItems,
         CancellationToken cancellationToken)
@@ -261,30 +264,49 @@ public class SyncPlaylistsTask : IScheduledTask
             playlist.Tracks.Count(),
             playlist.Title);
 
-        var playlistName = $"[LB] {playlist.Title}";
-        var playlistQuery = new InternalItemsQuery
-        {
-            IncludeItemTypes = [BaseItemKind.Playlist],
-            Name = playlistName,
-            User = user,
-        };
-        var existingPlaylist = _libraryManager.GetItemList(playlistQuery).FirstOrDefault();
+        var existingPlaylist = GetJellyfinPlaylist(userConfig, playlist.PlaylistId);
+        var playlistName = playlist.Title;
+        BaseItem? syncedPlaylist;
+
         if (existingPlaylist is not null)
         {
-            _logger.LogDebug("Deleting already existing playlist {Title}", playlist.Title);
-            _libraryManager.DeleteItem(
-                existingPlaylist,
-                new DeleteOptions { DeleteFileLocation = false });
+            _logger.LogDebug("Updating playlist {Name} with {Count} items", playlistName, jellyfinPlaylistTracks.Count);
+            await _playlistManager.UpdatePlaylist(new PlaylistUpdateRequest
+            {
+                Id = existingPlaylist.Id,
+                UserId = user.Id,
+                Name = playlistName,
+                Ids = jellyfinPlaylistTracks.Select(i => i.Id).ToArray(),
+            });
+
+            syncedPlaylist = _libraryManager.GetItemById(existingPlaylist.Id) ?? existingPlaylist;
+        }
+        else
+        {
+            _logger.LogDebug("Creating playlist {Name} with {Count} items", playlistName, jellyfinPlaylistTracks.Count);
+            var createdPlaylist = await _playlistManager.CreatePlaylist(new PlaylistCreationRequest
+            {
+                Name = playlistName,
+                UserId = user.Id,
+                ItemIdList = jellyfinPlaylistTracks.Select(i => i.Id).ToArray(),
+                MediaType = MediaType.Audio,
+            });
+
+            if (!Guid.TryParse(createdPlaylist.Id, out var createdPlaylistId))
+            {
+                throw new PluginException($"Failed to parse created playlist id '{createdPlaylist.Id}'");
+            }
+
+            syncedPlaylist = _libraryManager.GetItemById(createdPlaylistId);
+            if (syncedPlaylist is null)
+            {
+                throw new PluginException($"Failed to load created Jellyfin playlist '{createdPlaylistId}'");
+            }
+
+            _configService.SetPlaylistMapping(userConfig.JellyfinUserId, playlist.PlaylistId, createdPlaylistId);
         }
 
-        _logger.LogDebug("Creating playlist {Name} with {Count} items", playlistName, jellyfinPlaylistTracks.Count);
-        await _playlistManager.CreatePlaylist(new PlaylistCreationRequest
-        {
-            Name = playlistName,
-            UserId = user.Id,
-            ItemIdList = jellyfinPlaylistTracks.Select(i => i.Id).ToArray(),
-            MediaType = MediaType.Audio
-        });
+        await SetListenBrainzTag(syncedPlaylist, cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Successfully synced playlist {Name} with {Count} tracks",
@@ -318,6 +340,32 @@ public class SyncPlaylistsTask : IScheduledTask
     {
         return _defaultAllowedPatches.Any(patch =>
             sourcePatch.Contains(patch, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private BaseItem? GetJellyfinPlaylist(UserConfig userConfig, string listenBrainzPlaylistId)
+    {
+        var playlistId = _configService.GetPlaylistId(userConfig.JellyfinUserId, listenBrainzPlaylistId);
+        return playlistId is null ? null : _libraryManager.GetItemById(playlistId.Value);
+    }
+
+    private async Task SetListenBrainzTag(BaseItem playlist, CancellationToken cancellationToken)
+    {
+        if (playlist.Tags.Any(tag => string.Equals(tag, PlaylistTag, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        playlist.Tags =
+        [
+            .. playlist.Tags,
+            PlaylistTag,
+        ];
+
+        var parent = playlist.ParentId == Guid.Empty
+            ? playlist
+            : _libraryManager.GetItemById(playlist.ParentId) ?? playlist;
+
+        await _libraryManager.UpdateItemAsync(playlist, parent, ItemUpdateType.MetadataEdit, cancellationToken);
     }
 
     private async Task<BaseItem?> FindJellyfinItem(

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -360,7 +360,7 @@ public class SyncPlaylistsTask : IScheduledTask
         var legacyPlaylistQuery = new InternalItemsQuery
         {
             IncludeItemTypes = [BaseItemKind.Playlist],
-            Name = $"{PlaylistPrefix} ${playlist.Title}",
+            Name = $"{PlaylistPrefix} {playlist.Title}",
             User = user,
         };
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -274,6 +274,7 @@ public class SyncPlaylistsTask : IScheduledTask
                 return;
             }
 
+            playlists = DeduplicatePlaylistsByTitle(playlists);
             var playlistRatio = _userCountRatio / playlists.Count;
 
             var allowedLibraries = GetAllowedLibraries()
@@ -446,6 +447,29 @@ public class SyncPlaylistsTask : IScheduledTask
     {
         return _defaultAllowedPatches.Any(patch =>
             sourcePatch.Contains(patch, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private List<Playlist> DeduplicatePlaylistsByTitle(IReadOnlyCollection<Playlist> playlists)
+    {
+        return playlists
+            .GroupBy(playlist => playlist.Title, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var matchingPlaylists = group.OrderByDescending(playlist => playlist.CreatedAt).ToList();
+                var newestPlaylist = matchingPlaylists[0];
+
+                if (matchingPlaylists.Count > 1)
+                {
+                    _logger.LogInformation(
+                        "Found {Count} ListenBrainz playlists with title {PlaylistTitle}; syncing only newest playlist ({SelectedPlaylistId})",
+                        matchingPlaylists.Count,
+                        group.Key,
+                        newestPlaylist.PlaylistId);
+                }
+
+                return newestPlaylist;
+            })
+            .ToList();
     }
 
     private BaseItem? GetJellyfinPlaylist(User user, UserConfig userConfig, Playlist playlist)

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -346,13 +346,13 @@ public class SyncPlaylistsTask : IScheduledTask
     private BaseItem? GetJellyfinPlaylist(User user, UserConfig userConfig, Playlist playlist)
     {
         var playlistId = _configService.GetPlaylistId(userConfig.JellyfinUserId, playlist.PlaylistId);
-        if (playlistId is not null)
+        if (playlistId is null)
         {
-            return _libraryManager.GetItemById(playlistId.Value);
+            // Playlist may already exist before mappings were introduced
+            return MigratePlaylist(user, userConfig, playlist);
         }
 
-        // Playlist may already exist before mappings were introduced
-        return MigratePlaylist(user, userConfig, playlist);
+        return _libraryManager.GetItemById(playlistId.Value);
     }
 
     private BaseItem? MigratePlaylist(User user, UserConfig userConfig, Playlist playlist)


### PR DESCRIPTION
- Do not rely on name matching with prefix => introduce ID mapping system
- Add `ListenBrainz` tag to ListenBrainz playlists

Closes #160 

TODO:
- [x] ID mapping system
- [x] Tagging
- [ ] Fix playlist duplication

Notes:
- "rotation" playlists are expected to not migrate (except 2 latest)
- Playlists without [LB] prefix will be ignored as these were treated as custom until now (this may create duplicate playlists by name)