### PR TITLE
Sync user playlists when Sync All Playlists is enabled

### DIFF
--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IListenBrainzApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Interfaces/IListenBrainzApiClient.cs
@@ -57,6 +57,14 @@ public interface IListenBrainzApiClient
     public Task<GetCreatedForPlaylistsResponse> GetCreatedForPlaylists(GetCreatedForPlaylistsRequest request, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Get playlists owned by a specified user.
+    /// </summary>
+    /// <param name="request">User-owned playlists request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Request response.</returns>
+    public Task<GetUserPlaylistsResponse> GetUserPlaylists(GetUserPlaylistsRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Get detailed information for a specific playlist.
     /// </summary>
     /// <param name="request">Playlist details request.</param>

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/ListenBrainzApiClient.cs
@@ -61,6 +61,12 @@ public class ListenBrainzApiClient : IListenBrainzApiClient
     }
 
     /// <inheritdoc />
+    public async Task<GetUserPlaylistsResponse> GetUserPlaylists(GetUserPlaylistsRequest request, CancellationToken cancellationToken)
+    {
+        return await _apiClient.SendGetRequest<GetUserPlaylistsRequest, GetUserPlaylistsResponse>(request, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<GetPlaylistResponse> GetPlaylist(GetPlaylistRequest request, CancellationToken cancellationToken)
     {
         return await _apiClient.SendGetRequest<GetPlaylistRequest, GetPlaylistResponse>(request, cancellationToken);

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Requests/GetUserPlaylistsRequest.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Requests/GetUserPlaylistsRequest.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Text;
+using Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
+using Jellyfin.Plugin.ListenBrainz.Api.Resources;
+
+namespace Jellyfin.Plugin.ListenBrainz.Api.Models.Requests;
+
+/// <summary>
+/// User-owned playlists request.
+/// </summary>
+public class GetUserPlaylistsRequest : IListenBrainzRequest
+{
+    private readonly string _userName;
+    private readonly CompositeFormat _endpointFormat;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetUserPlaylistsRequest"/> class.
+    /// </summary>
+    /// <param name="userName">Name of the user who owns the playlists.</param>
+    /// <param name="playlistsCount">Number of playlists to fetch.</param>
+    /// <param name="offset">Playlist list offset.</param>
+    public GetUserPlaylistsRequest(string userName, int playlistsCount = Limits.DefaultItemsPerGet, int offset = 0)
+    {
+        _endpointFormat = CompositeFormat.Parse(Endpoints.UserPlaylists);
+        _userName = userName;
+        BaseUrl = General.BaseUrl;
+        QueryDict = new Dictionary<string, string>
+        {
+            { "count", playlistsCount.ToString(NumberFormatInfo.InvariantInfo) },
+            { "offset", offset.ToString(NumberFormatInfo.InvariantInfo) }
+        };
+    }
+
+    /// <inheritdoc />
+    public string? ApiToken { get; init; }
+
+    /// <inheritdoc />
+    public string Endpoint => string.Format(CultureInfo.InvariantCulture, _endpointFormat, _userName);
+
+    /// <inheritdoc />
+    public string BaseUrl { get; init; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string> QueryDict { get; }
+}

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/GetCreatedForPlaylistsResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/GetCreatedForPlaylistsResponse.cs
@@ -1,48 +1,8 @@
-using Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
-using Newtonsoft.Json;
-
 namespace Jellyfin.Plugin.ListenBrainz.Api.Models.Responses;
 
 /// <summary>
 /// 'Created for' playlists response.
 /// </summary>
-public class GetCreatedForPlaylistsResponse : IListenBrainzResponse
+public class GetCreatedForPlaylistsResponse : PlaylistsResponse
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GetCreatedForPlaylistsResponse"/> class.
-    /// </summary>
-    public GetCreatedForPlaylistsResponse()
-    {
-        WrappedPlaylists = new List<WrappedPlaylist>();
-    }
-
-    /// <inheritdoc />
-    public bool IsOk { get; set; }
-
-    /// <inheritdoc />
-    public bool IsNotOk => !IsOk;
-
-    /// <summary>
-    /// Gets or sets requested count of playlists (page size).
-    /// </summary>
-    public int Count { get; set; }
-
-    /// <summary>
-    /// Gets or sets paging offset (see <see cref="Count"/>).
-    /// </summary>
-    public int Offset { get; set; }
-
-    /// <summary>
-    /// Gets or sets total playlist count.
-    /// </summary>
-    public int PlaylistCount { get; set; }
-
-    /// <summary>
-    /// Gets playlists data.
-    /// </summary>
-    [JsonIgnore]
-    public IEnumerable<Playlist> Playlists => WrappedPlaylists.Select(wp => wp.Playlist);
-
-    [JsonProperty("playlists")]
-    private IEnumerable<WrappedPlaylist> WrappedPlaylists { get; set; }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/GetUserPlaylistsResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/GetUserPlaylistsResponse.cs
@@ -1,0 +1,8 @@
+namespace Jellyfin.Plugin.ListenBrainz.Api.Models.Responses;
+
+/// <summary>
+/// User-owned playlists response.
+/// </summary>
+public class GetUserPlaylistsResponse : PlaylistsResponse
+{
+}

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/PlaylistsResponse.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Models/Responses/PlaylistsResponse.cs
@@ -1,0 +1,48 @@
+using Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
+using Newtonsoft.Json;
+
+namespace Jellyfin.Plugin.ListenBrainz.Api.Models.Responses;
+
+/// <summary>
+/// Base response for endpoints returning a paged list of playlists.
+/// </summary>
+public abstract class PlaylistsResponse : IListenBrainzResponse
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaylistsResponse"/> class.
+    /// </summary>
+    protected PlaylistsResponse()
+    {
+        WrappedPlaylists = new List<WrappedPlaylist>();
+    }
+
+    /// <inheritdoc />
+    public bool IsOk { get; set; }
+
+    /// <inheritdoc />
+    public bool IsNotOk => !IsOk;
+
+    /// <summary>
+    /// Gets or sets requested count of playlists (page size).
+    /// </summary>
+    public int Count { get; set; }
+
+    /// <summary>
+    /// Gets or sets paging offset (see <see cref="Count"/>).
+    /// </summary>
+    public int Offset { get; set; }
+
+    /// <summary>
+    /// Gets or sets total playlist count.
+    /// </summary>
+    public int PlaylistCount { get; set; }
+
+    /// <summary>
+    /// Gets playlists data.
+    /// </summary>
+    [JsonIgnore]
+    public IEnumerable<Playlist> Playlists => WrappedPlaylists.Select(wp => wp.Playlist);
+
+    [JsonProperty("playlists")]
+    private IEnumerable<WrappedPlaylist> WrappedPlaylists { get; set; }
+}

--- a/src/Jellyfin.Plugin.ListenBrainz.Api/Resources/Endpoints.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz.Api/Resources/Endpoints.cs
@@ -46,6 +46,11 @@ public static class Endpoints
     public const string CreatedForPlaylists = UserEndpointBase + "/{0}/playlists/createdfor";
 
     /// <summary>
+    /// Endpoint for playlists owned by a user.
+    /// </summary>
+    public const string UserPlaylists = UserEndpointBase + "/{0}/playlists";
+
+    /// <summary>
     /// Endpoint for playlist details.
     /// </summary>
     public const string PlaylistDetails = "playlist/{0}";

--- a/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListenBrainzService.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Interfaces/IListenBrainzService.cs
@@ -115,6 +115,15 @@ public interface IListenBrainzService
     public Task<IEnumerable<Playlist>> GetCreatedForPlaylistsAsync(UserConfig config, int count, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Get all playlists owned by the user.
+    /// </summary>
+    /// <param name="config">ListenBrainz user configuration.</param>
+    /// <param name="count">Number of playlists to fetch per request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Collection of the user's own playlists (both public and private).</returns>
+    public Task<IEnumerable<Playlist>> GetUserPlaylistsAsync(UserConfig config, int count, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Get a single playlist by its identifier.
     /// </summary>
     /// <param name="config">ListenBrainz user configuration.</param>

--- a/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/index.html
+++ b/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/index.html
@@ -139,7 +139,8 @@
                                 <span>Sync all playlists from ListenBrainz</span>
                             </label>
                             <div class="fieldDescription">Sync all playlists from ListenBrainz, including
-                                suggestion/recommendation playlists.
+                                suggestion/recommendation playlists and the user's own playlists
+                                (both public and private).
                             </div>
                         </div>
                         <div>

--- a/src/Jellyfin.Plugin.ListenBrainz/Services/DefaultListenBrainzService.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Services/DefaultListenBrainzService.cs
@@ -318,6 +318,44 @@ public class DefaultListenBrainzService : IListenBrainzService
     }
 
     /// <inheritdoc />
+    public async Task<IEnumerable<Playlist>> GetUserPlaylistsAsync(UserConfig config, int count, CancellationToken cancellationToken)
+    {
+        var playlists = new List<Playlist>();
+        int offset = 0;
+        GetUserPlaylistsResponse response;
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var request = new GetUserPlaylistsRequest(config.UserName, count, offset)
+            {
+                ApiToken = config.PlaintextApiToken,
+                BaseUrl = _pluginConfig.ListenBrainzApiUrl,
+            };
+
+            try
+            {
+                response = await _apiClient.GetUserPlaylists(request, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug("Exception when getting user playlists: {Message}", e.Message);
+                throw new ServiceException("Getting user playlists failed", e);
+            }
+
+            if (response.IsNotOk)
+            {
+                throw new ServiceException("Getting user playlists failed");
+            }
+
+            playlists.AddRange(response.Playlists);
+            offset += response.Count;
+        }
+        while (offset < response.PlaylistCount);
+
+        return playlists;
+    }
+
+    /// <inheritdoc />
     public async Task<Playlist> GetPlaylistAsync(UserConfig config, string playlistId, CancellationToken cancellationToken)
     {
         var request = new GetPlaylistRequest(playlistId, false)

--- a/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Tasks/SyncPlaylistsTask.cs
@@ -155,6 +155,19 @@ public class SyncPlaylistsTask : IScheduledTask
                     Limits.MaxItemsPerGet,
                     cancellationToken)
             ).ToList();
+
+            // The user's own playlists are only synced when syncing of all playlists is enabled.
+            if (_configService.IsAllPlaylistsSyncEnabled)
+            {
+                var ownPlaylists = await _listenBrainz.GetUserPlaylistsAsync(
+                    userConfig,
+                    Limits.MaxItemsPerGet,
+                    cancellationToken);
+
+                var knownPlaylistIds = playlists.Select(pl => pl.PlaylistId).ToHashSet();
+                playlists.AddRange(ownPlaylists.Where(pl => knownPlaylistIds.Add(pl.PlaylistId)));
+            }
+
             _logger.LogInformation("Found {Count} playlists for user {Username}", playlists.Count, userConfig.UserName);
 
             if (playlists.Count == 0)

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Services/DefaultListenBrainzServiceTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Services/DefaultListenBrainzServiceTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.ListenBrainz.Api;
+using Jellyfin.Plugin.ListenBrainz.Api.Interfaces;
+using Jellyfin.Plugin.ListenBrainz.Api.Models.Requests;
+using Jellyfin.Plugin.ListenBrainz.Api.Models.Responses;
+using Jellyfin.Plugin.ListenBrainz.Configuration;
+using Jellyfin.Plugin.ListenBrainz.Exceptions;
+using Jellyfin.Plugin.ListenBrainz.Interfaces;
+using Jellyfin.Plugin.ListenBrainz.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Jellyfin.Plugin.ListenBrainz.Tests.Services;
+
+public class DefaultListenBrainzServiceTests
+{
+    private readonly Mock<IListenBrainzApiClient> _apiClientMock;
+    private readonly Mock<IPluginConfigService> _pluginConfigMock;
+    private readonly DefaultListenBrainzService _service;
+
+    public DefaultListenBrainzServiceTests()
+    {
+        _apiClientMock = new Mock<IListenBrainzApiClient>();
+        _pluginConfigMock = new Mock<IPluginConfigService>();
+        _pluginConfigMock.SetupGet(pc => pc.ListenBrainzApiUrl).Returns("https://api.listenbrainz.org/1/");
+
+        _service = new DefaultListenBrainzService(
+            NullLogger.Instance,
+            _apiClientMock.Object,
+            _pluginConfigMock.Object);
+    }
+
+    private static UserConfig GetUserConfig() => new()
+    {
+        JellyfinUserId = Guid.NewGuid(),
+        UserName = "foobar",
+        ApiToken = "token",
+        PlaintextApiToken = "token",
+    };
+
+    private static GetUserPlaylistsResponse BuildResponse(int count, int offset, int playlistCount, params string[] playlistIds)
+    {
+        var playlists = string.Join(
+            ',',
+            playlistIds.Select(id => $"{{\"playlist\":{{\"identifier\":\"https://listenbrainz.org/playlist/{id}\",\"title\":\"{id}\"}}}}"));
+        var json = $"{{\"count\":{count},\"offset\":{offset},\"playlist_count\":{playlistCount},\"playlists\":[{playlists}]}}";
+
+        var response = JsonConvert.DeserializeObject<GetUserPlaylistsResponse>(json, BaseApiClient.SerializerSettings)!;
+        response.IsOk = true;
+        return response;
+    }
+
+    [Fact]
+    public async Task GetUserPlaylistsAsync_ReturnsAllPlaylists_AcrossMultiplePages()
+    {
+        _apiClientMock
+            .SetupSequence(c => c.GetUserPlaylists(It.IsAny<GetUserPlaylistsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildResponse(1, 0, 2, "playlist-a"))
+            .ReturnsAsync(BuildResponse(1, 1, 2, "playlist-b"));
+
+        var result = (await _service.GetUserPlaylistsAsync(GetUserConfig(), 1, CancellationToken.None)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("playlist-a", result[0].PlaylistId);
+        Assert.Equal("playlist-b", result[1].PlaylistId);
+        _apiClientMock.Verify(
+            c => c.GetUserPlaylists(It.IsAny<GetUserPlaylistsRequest>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetUserPlaylistsAsync_ForwardsUserNameApiTokenAndBaseUrl()
+    {
+        _apiClientMock
+            .Setup(c => c.GetUserPlaylists(It.IsAny<GetUserPlaylistsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildResponse(0, 0, 0));
+
+        await _service.GetUserPlaylistsAsync(GetUserConfig(), 25, CancellationToken.None);
+
+        _apiClientMock.Verify(
+            c => c.GetUserPlaylists(
+                It.Is<GetUserPlaylistsRequest>(r =>
+                    r.Endpoint == "user/foobar/playlists"
+                    && r.ApiToken == "token"
+                    && r.BaseUrl == "https://api.listenbrainz.org/1/"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUserPlaylistsAsync_Throws_WhenResponseIsNotOk()
+    {
+        var response = BuildResponse(0, 0, 0);
+        response.IsOk = false;
+        _apiClientMock
+            .Setup(c => c.GetUserPlaylists(It.IsAny<GetUserPlaylistsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        await Assert.ThrowsAsync<ServiceException>(() =>
+            _service.GetUserPlaylistsAsync(GetUserConfig(), 25, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetUserPlaylistsAsync_WrapsUnderlyingException()
+    {
+        var inner = new InvalidOperationException("boom");
+        _apiClientMock
+            .Setup(c => c.GetUserPlaylists(It.IsAny<GetUserPlaylistsRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(inner);
+
+        var ex = await Assert.ThrowsAsync<ServiceException>(() =>
+            _service.GetUserPlaylistsAsync(GetUserConfig(), 25, CancellationToken.None));
+
+        Assert.Same(inner, ex.InnerException);
+    }
+
+    [Fact]
+    public async Task GetUserPlaylistsAsync_ThrowsWhenCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            _service.GetUserPlaylistsAsync(GetUserConfig(), 25, cts.Token));
+
+        _apiClientMock.Verify(
+            c => c.GetUserPlaylists(It.IsAny<GetUserPlaylistsRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/SyncPlaylistsTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Tasks/SyncPlaylistsTaskTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.ListenBrainz.Api.Models;
+using Jellyfin.Plugin.ListenBrainz.Configuration;
+using Jellyfin.Plugin.ListenBrainz.Interfaces;
+using Jellyfin.Plugin.ListenBrainz.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Playlists;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using Playlist = Jellyfin.Plugin.ListenBrainz.Api.Models.Playlist;
+
+namespace Jellyfin.Plugin.ListenBrainz.Tests.Tasks;
+
+public class SyncPlaylistsTaskTests
+{
+    private readonly Mock<ILibraryManager> _libraryManagerMock;
+    private readonly Mock<IUserManager> _userManagerMock;
+    private readonly Mock<IPlaylistManager> _playlistManagerMock;
+    private readonly Mock<IListenBrainzService> _listenBrainzServiceMock;
+    private readonly Mock<IMetadataProviderService> _metadataProviderServiceMock;
+    private readonly Mock<IPluginConfigService> _configServiceMock;
+    private readonly SyncPlaylistsTask _task;
+    private readonly Mock<IProgress<double>> _progressMock;
+
+    public SyncPlaylistsTaskTests()
+    {
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock
+            .Setup(lf => lf.CreateLogger(It.IsAny<string>()))
+            .Returns(NullLogger.Instance);
+
+        _libraryManagerMock = new Mock<ILibraryManager>();
+        _userManagerMock = new Mock<IUserManager>();
+        _playlistManagerMock = new Mock<IPlaylistManager>();
+        _listenBrainzServiceMock = new Mock<IListenBrainzService>();
+        _metadataProviderServiceMock = new Mock<IMetadataProviderService>();
+        _configServiceMock = new Mock<IPluginConfigService>();
+
+        _task = new SyncPlaylistsTask(
+            loggerFactoryMock.Object,
+            _libraryManagerMock.Object,
+            _userManagerMock.Object,
+            _playlistManagerMock.Object,
+            _listenBrainzServiceMock.Object,
+            _metadataProviderServiceMock.Object,
+            _configServiceMock.Object);
+
+        _progressMock = new Mock<IProgress<double>>();
+    }
+
+    private static User GetUser() => new("foobar", "auth-provider-id", "pw-reset-provider-id");
+
+    private static UserConfig GetUserConfig(Guid userId) => new()
+    {
+        JellyfinUserId = userId,
+        UserName = "foobar",
+        IsPlaylistsSyncEnabled = true,
+    };
+
+    private static Playlist GetPlaylist(string id) => new() { Identifier = $"https://listenbrainz.org/playlist/{id}" };
+
+    private void SetupCommonMocks(User user)
+    {
+        _configServiceMock
+            .SetupGet(cs => cs.LibraryConfigs)
+            .Returns([new LibraryConfig { Id = Guid.NewGuid(), IsAllowed = true }]);
+
+        _userManagerMock
+            .Setup(um => um.GetUserById(user.Id))
+            .Returns(user);
+
+        _libraryManagerMock
+            .Setup(lm => lm.GetItemById(It.IsAny<Guid>()))
+            .Returns((BaseItem?)null);
+
+        _libraryManagerMock
+            .Setup(lm => lm.GetItemList(It.IsAny<InternalItemsQuery>(), It.IsAny<List<BaseItem>>()))
+            .Returns(new List<BaseItem>());
+
+        _listenBrainzServiceMock
+            .Setup(lb => lb.GetPlaylistAsync(It.IsAny<UserConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("not needed for this test"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MergesOwnPlaylists_DedupingAgainstCreatedForPlaylists_WhenAllPlaylistsSyncEnabled()
+    {
+        var user = GetUser();
+        var userConfig = GetUserConfig(user.Id);
+        SetupCommonMocks(user);
+
+        _configServiceMock.SetupGet(cs => cs.UserConfigs).Returns([userConfig]);
+        _configServiceMock.SetupGet(cs => cs.IsAllPlaylistsSyncEnabled).Returns(true);
+
+        _listenBrainzServiceMock
+            .Setup(lb => lb.GetCreatedForPlaylistsAsync(userConfig, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([GetPlaylist("shared-id")]);
+        _listenBrainzServiceMock
+            .Setup(lb => lb.GetUserPlaylistsAsync(userConfig, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([GetPlaylist("shared-id"), GetPlaylist("own-id")]);
+
+        await _task.ExecuteAsync(_progressMock.Object, CancellationToken.None);
+
+        _listenBrainzServiceMock.Verify(
+            lb => lb.GetUserPlaylistsAsync(userConfig, It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _listenBrainzServiceMock.Verify(
+            lb => lb.GetPlaylistAsync(userConfig, "shared-id", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _listenBrainzServiceMock.Verify(
+            lb => lb.GetPlaylistAsync(userConfig, "own-id", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _listenBrainzServiceMock.Verify(
+            lb => lb.GetPlaylistAsync(It.IsAny<UserConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotFetchOwnPlaylists_WhenAllPlaylistsSyncDisabled()
+    {
+        var user = GetUser();
+        var userConfig = GetUserConfig(user.Id);
+        SetupCommonMocks(user);
+
+        _configServiceMock.SetupGet(cs => cs.UserConfigs).Returns([userConfig]);
+        _configServiceMock.SetupGet(cs => cs.IsAllPlaylistsSyncEnabled).Returns(false);
+
+        _listenBrainzServiceMock
+            .Setup(lb => lb.GetCreatedForPlaylistsAsync(userConfig, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([GetPlaylist("shared-id")]);
+
+        await _task.ExecuteAsync(_progressMock.Object, CancellationToken.None);
+
+        _listenBrainzServiceMock.Verify(
+            lb => lb.GetUserPlaylistsAsync(It.IsAny<UserConfig>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
From the documentation I expected the "Sync All Playlists" option to actually, sync all of the play lists available on ListenBrainz for a user.

This change implements that functionality, by extending the SyncPlaylistsTask implementation to also fetch the users playlists.

Closes: https://github.com/lyarenei/jellyfin-plugin-listenbrainz/issues/159