### PR TITLE
Playlist sync settings migration

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.5.1.1"
+version: "6.5.2.1"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -17,5 +17,4 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
   This version contains the following changes:
-    - Allow override of delimiters for multiple MBIDs in an artist metadata field
-    - Provide UA header for ListenBrainz API calls
+    - Migration of playlist sync settings

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -47,6 +47,10 @@ artist, and Jellyfin has no concept of a hated track.
 This setting no longer does anything and will be removed in a future version. Use
 [Enable generated playlist sync](#enable-generated-playlist-sync) instead.
 
+If you had this setting enabled, the plugin turns on [Enable generated playlist sync](#enable-generated-playlist-sync)
+for you on the first server start after the update and clears this setting. Users who already had the generated
+playlist sync enabled keep their playlist type selection.
+
 ##### Enable generated playlist sync
 
 Enable syncing of the playlists that ListenBrainz generates for the selected user into Jellyfin. Choose which types
@@ -152,6 +156,9 @@ the [MusicBrainz integration](#fetch-additional-metadata-from-musicbrainz) is en
 ##### Sync all playlists from ListenBrainz (deprecated)
 
 This setting no longer does anything and will be removed in a future version.
+
+If you had this setting enabled, all playlist types are enabled for the migrated users instead of the default
+selection, see [Enable playlist sync (deprecated)](#enable-playlist-sync-deprecated).
 
 ##### MBID delimiter override
 

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/LegacyPlaylistSyncMigration.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/LegacyPlaylistSyncMigration.cs
@@ -1,0 +1,43 @@
+namespace Jellyfin.Plugin.ListenBrainz.Configuration;
+
+/// <summary>
+/// Migration of the deprecated playlist sync settings to the new playlist sync settings.
+/// </summary>
+internal static class LegacyPlaylistSyncMigration
+{
+    internal static bool Apply(PluginConfiguration config)
+    {
+        var syncAllPlaylists = config.IsAllPlaylistsSyncEnabled;
+        var userConfigs = config.UserConfigs.Where(uc => uc.IsPlaylistsSyncEnabled).ToList();
+        if (userConfigs.Count == 0 && !syncAllPlaylists)
+        {
+            return false;
+        }
+
+        foreach (var userConfig in userConfigs)
+        {
+            // Old, deprecated setting => set to false
+            userConfig.IsPlaylistsSyncEnabled = false;
+
+            // If already using new settings => ignore
+            if (userConfig.IsGeneratedPlaylistsSyncEnabled)
+            {
+                continue;
+            }
+
+            // Enable new playlist sync settings for user
+            userConfig.IsGeneratedPlaylistsSyncEnabled = true;
+            if (syncAllPlaylists)
+            {
+                userConfig.IsWeeklyJamsSyncEnabled = true;
+                userConfig.IsWeeklyExplorationSyncEnabled = true;
+                userConfig.IsTopDiscoveriesSyncEnabled = true;
+                userConfig.IsTopMissedRecordingsSyncEnabled = true;
+            }
+        }
+
+        // Disable deprecated setting
+        config.IsAllPlaylistsSyncEnabled = false;
+        return true;
+    }
+}

--- a/src/Jellyfin.Plugin.ListenBrainz/Plugin.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Plugin.cs
@@ -22,6 +22,10 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public Plugin(IApplicationPaths paths, IXmlSerializer xmlSerializer) : base(paths, xmlSerializer)
     {
         Instance = this;
+        if (LegacyPlaylistSyncMigration.Apply(Configuration))
+        {
+            SaveConfiguration();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
While reworked playlist sync did not migrate existing playlists to the new system, the user settings should have been migrated to prevent surprises.

It's a bit too late, but better than never.