### PR TITLE
Fix plugin configuration wipe (after installing 6.5.1.1 or .2.1)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -17,4 +17,4 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
   This version contains the following changes:
-    - Fix plugin configration wipe after installing version 6.5.1.1
+    - Fix plugin configration wipe after installing version 6.5.1.1 (or .2.1)

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.5.2.1"
+version: "6.5.2.2"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.5.2.2"
+version: "6.5.2.3"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/build.yaml
+++ b/build.yaml
@@ -17,4 +17,4 @@ artifacts:
   - "Jellyfin.Plugin.ListenBrainz.MusicBrainzApi.dll"
 changelog: >
   This version contains the following changes:
-    - Migration of playlist sync settings
+    - Fix plugin configration wipe after installing version 6.5.1.1

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "ListenBrainz"
 guid: "59B20823-AAFE-454C-A393-17427F518631"
-version: "6.5.2.3"
+version: "6.5.3.3"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 overview: "Track your music habits with ListenBrainz."

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/PluginConfiguration.cs
@@ -77,7 +77,14 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets the default delimiters used to split multiple MBIDs in metadata.
     /// </summary>
     [XmlIgnore]
-    public static string DefaultMbidDelimiters => ";,/\u001F";
+    public static string DefaultMbidDelimiters => ";,/";
+
+    /// <summary>
+    /// Gets delimiters which always split multiple MBIDs, on top of <see cref="MbidDelimiters"/>.
+    /// Cannot be part of the default set due to XML limitations.
+    /// </summary>
+    [XmlIgnore]
+    public static string ImplicitMbidDelimiters => "\u001F";
 
     /// <summary>
     /// Gets or sets a value indicating whether MusicBrainz integration is enabled.

--- a/src/Jellyfin.Plugin.ListenBrainz/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Configuration/PluginConfiguration.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using System.Xml;
 using System.Xml.Serialization;
 using MediaBrowser.Model.Plugins;
 
@@ -65,7 +66,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public string MbidDelimiters
     {
         get => _mbidDelimitersOverride ?? DefaultMbidDelimiters;
-        set => _mbidDelimitersOverride = string.IsNullOrEmpty(value) ? null : value;
+        set
+        {
+            var sanitized = SanitizeForXml(value);
+            _mbidDelimitersOverride = string.IsNullOrEmpty(sanitized) ? null : sanitized;
+        }
     }
 
     /// <summary>
@@ -132,5 +137,15 @@ public class PluginConfiguration : BasePluginConfiguration
     {
         get => _isAllPlaylistsSyncEnabled ?? false;
         set => _isAllPlaylistsSyncEnabled = value;
+    }
+
+    private static string SanitizeForXml(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return new string(value.Where(XmlConvert.IsXmlChar).ToArray());
     }
 }

--- a/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Extensions/AudioExtensions.cs
@@ -43,7 +43,8 @@ public static class AudioExtensions
         AudioItemMetadata? itemMetadata = null,
         string? mbidDelimiters = null)
     {
-        var delimiters = (mbidDelimiters ?? PluginConfiguration.DefaultMbidDelimiters).ToCharArray();
+        var delimiters = ((mbidDelimiters ?? PluginConfiguration.DefaultMbidDelimiters) +
+                          PluginConfiguration.ImplicitMbidDelimiters).ToCharArray();
         string allArtists = string.Join(", ", item.Artists.TakeWhile(name => !string.IsNullOrEmpty(name)));
         return new Listen
         {

--- a/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/constants.ts
+++ b/src/Jellyfin.Plugin.ListenBrainz/Pages/Configuration/constants.ts
@@ -23,4 +23,4 @@ export const userDefaults: PluginUserConfig = {
 
 export const defaultListenBrainzApiUrl = "https://api.listenbrainz.org";
 export const defaultMusicBrainzApiUrl = "https://musicbrainz.org";
-export const defaultMbidDelimiters = ";,/\u001F";
+export const defaultMbidDelimiters = ";,/";

--- a/src/Jellyfin.Plugin.ListenBrainz/Plugin.cs
+++ b/src/Jellyfin.Plugin.ListenBrainz/Plugin.cs
@@ -22,10 +22,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public Plugin(IApplicationPaths paths, IXmlSerializer xmlSerializer) : base(paths, xmlSerializer)
     {
         Instance = this;
-        if (LegacyPlaylistSyncMigration.Apply(Configuration))
-        {
-            SaveConfiguration();
-        }
+        ApplyLegacyPlaylistSyncMigration();
     }
 
     /// <summary>
@@ -99,6 +96,23 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                     GetType().Namespace),
             },
         ];
+    }
+
+    private void ApplyLegacyPlaylistSyncMigration()
+    {
+        try
+        {
+            if (LegacyPlaylistSyncMigration.Apply(Configuration))
+            {
+                SaveConfiguration();
+            }
+        }
+        catch (Exception)
+        {
+            // In-memory config => does not touch the actual file
+            // TODO: consider current file backup before future migrations
+            Configuration = new PluginConfiguration();
+        }
     }
 
     /// <summary>

--- a/tests/Jellyfin.Plugin.ListenBrainz.Tests/Extensions/AudioExtensionsTests.cs
+++ b/tests/Jellyfin.Plugin.ListenBrainz.Tests/Extensions/AudioExtensionsTests.cs
@@ -53,6 +53,21 @@ public class AudioExtensionsTests
     }
 
     [Fact]
+    public void AsListen_SplitsArtistMbids_OnUnitSeparatorDelimiter_WithCustomDelimiters()
+    {
+        // The unit separator cannot be stored in the XML config, so it always applies
+        // on top of whatever delimiters are configured.
+        var unitSeparator = char.ConvertFromUtf32(0x1F);
+        var audio = GetAudio($"{ArtistMbid1}{unitSeparator}{ArtistMbid2}");
+
+        var listen = audio.AsListen(mbidDelimiters: "|");
+
+        Assert.Equal(
+            [ArtistMbid1, ArtistMbid2],
+            listen.TrackMetadata.AdditionalInfo!.ArtistMbids);
+    }
+
+    [Fact]
     public void AsListen_TrimsWhitespace_AfterSplitting()
     {
         var audio = GetAudio($"{ArtistMbid1} , {ArtistMbid2}");


### PR DESCRIPTION
Fix plugin configuration wipe caused by processing character that is not valid in XML (as part of the default MBID delimiters).

Reported in #183 